### PR TITLE
Fix imports to use task_recovery module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,6 @@ warp = "0.3"
 
 [features]
 default = ["full"]
+full = []
 
 # Enable optional features for specific use cases

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,7 @@
 use warp::Filter;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use crate::task_recovery_module::{TaskRecoveryManager, Task};
+use crate::task_recovery::{TaskRecoveryManager, Task};
 use uuid::Uuid;
 use warp::http::StatusCode;
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,7 +1,7 @@
 // testing.rs: Implements integration tests for the distributed neural network system.
 
-use crate::task_recovery_module::{TaskRecoveryManager, Task};
-use crate::api_module::Api;
+use crate::task_recovery::{TaskRecoveryManager, Task};
+use crate::api::Api;
 use std::sync::Arc;
 use uuid::Uuid;
 use warp::http::StatusCode;


### PR DESCRIPTION
## Summary
- fix `use` paths in `api.rs` and `testing.rs`
- define empty `full` feature in Cargo.toml for `cargo check`

## Testing
- `cargo check` *(fails: unresolved crate dependencies and compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f43cd8764832889324c51d5c1450c