### PR TITLE
Read JWT secret from environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,6 @@ warp = "0.3"
 
 [features]
 default = ["full"]
+full = []
 
 # Enable optional features for specific use cases

--- a/README.md
+++ b/README.md
@@ -108,9 +108,10 @@ cockroach start-single-node --insecure --listen-addr=localhost
    Create a `config/` directory and add configuration files. You can start by copying the example configuration:
    ```bash
    mkdir -p config
-   cp config/default.example config/default.toml
-   ```
-   Set up your environment variables or update the configuration files for your local setup.
+  cp config/default.example config/default.toml
+  ```
+  Set up your environment variables or update the configuration files for your local setup.
+   The JWT secret key must be provided via the `JWT_SECRET_KEY` environment variable.
 
 5. **Build the project:**
    Compile the project to ensure there are no issues.

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,13 +1,14 @@
 // security.rs: Implements security mechanisms including encryption, decryption, and authentication for nodes.
 
-use jsonwebtoken::{encode, decode, Header, Validation, EncodingKey, DecodingKey, TokenData};
-use serde::{Deserialize, Serialize};
-use std::error::Error;
-use tracing::{info, error};
-use chrono::{Utc, Duration};
+use base64::{decode as base64_decode, encode as base64_encode};
+use chrono::{Duration, Utc};
 use hmac::{Hmac, Mac};
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
+use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use base64::{encode as base64_encode, decode as base64_decode};
+use std::env;
+use std::error::Error;
+use tracing::{error, info};
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
@@ -16,9 +17,15 @@ struct Claims {
     exp: usize,   // Expiration time as a UNIX timestamp
 }
 
-const SECRET_KEY: &str = "your_secret_key_here";
+fn get_secret_key() -> Result<String, env::VarError> {
+    env::var("JWT_SECRET_KEY")
+}
 
-pub fn generate_token(node_id: &str, role: &str, expiration_minutes: i64) -> Result<String, Box<dyn Error>> {
+pub fn generate_token(
+    node_id: &str,
+    role: &str,
+    expiration_minutes: i64,
+) -> Result<String, Box<dyn Error>> {
     let expiration = Utc::now() + Duration::minutes(expiration_minutes);
     let claims = Claims {
         sub: node_id.to_owned(),
@@ -26,18 +33,30 @@ pub fn generate_token(node_id: &str, role: &str, expiration_minutes: i64) -> Res
         exp: expiration.timestamp() as usize,
     };
 
-    let token = encode(&Header::default(), &claims, &EncodingKey::from_secret(SECRET_KEY.as_ref()))?;
-    info!("Generated token for node_id: {} with role: {}", node_id, role);
+    let secret_key = get_secret_key()?;
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret_key.as_ref()),
+    )?;
+    info!(
+        "Generated token for node_id: {} with role: {}",
+        node_id, role
+    );
     Ok(token)
 }
 
 pub fn verify_token(token: &str) -> Result<TokenData<Claims>, Box<dyn Error>> {
+    let secret_key = get_secret_key()?;
     let token_data = decode::<Claims>(
         token,
-        &DecodingKey::from_secret(SECRET_KEY.as_ref()),
+        &DecodingKey::from_secret(secret_key.as_ref()),
         &Validation::default(),
     )?;
-    info!("Verified token for node_id: {} with role: {}", token_data.claims.sub, token_data.claims.role);
+    info!(
+        "Verified token for node_id: {} with role: {}",
+        token_data.claims.sub, token_data.claims.role
+    );
     Ok(token_data)
 }
 
@@ -63,6 +82,7 @@ mod tests {
 
     #[test]
     fn test_generate_and_verify_token() {
+        std::env::set_var("JWT_SECRET_KEY", "test_secret_key");
         let node_id = "test_node";
         let role = "teacher";
         let token = generate_token(node_id, role, 60).unwrap();


### PR DESCRIPTION
## Summary
- load secret key at runtime from `JWT_SECRET_KEY`
- set up `JWT_SECRET_KEY` in security tests
- document required env var in README
- add missing feature declaration to Cargo.toml

## Testing
- `cargo test` *(fails: could not compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683f43cfe6788328a506120d34a90fa8