### PR TITLE
Add tokio-postgres database abstraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,17 @@ lapin = "2.0"
 
 # Web framework for REST API
 warp = "0.3"
+tokio-postgres = "0.7"
+futures-util = "0.3"
+chrono = { version = "0.4", features = ["serde"] }
+base64 = "0.21"
 
 # JSON serialization/deserialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # UUID for unique identifiers
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 
 # Prometheus metrics collection
 prometheus = "0.13"
@@ -56,5 +60,6 @@ warp = "0.3"
 
 [features]
 default = ["full"]
+full = []
 
 # Enable optional features for specific use cases

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Start a single-node CockroachDB cluster (for local development):
 cockroach start-single-node --insecure --listen-addr=localhost
 ```
 
+Set the connection string for the application. The project uses
+`tokio-postgres` to connect to CockroachDB, so provide a standard
+PostgreSQL URL:
+
+```bash
+export DATABASE_URL="postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+```
+
 4. **Configure the project:**
    Create a `config/` directory and add configuration files. You can start by copying the example configuration:
    ```bash

--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -57,7 +57,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     while let Some(result) = consumer.next().await {
         match result {
-            Ok((_, delivery)) => {
+            Ok(delivery) => {
                 match serde_json::from_slice::<TaskMessage>(&delivery.data) {
                     Ok(task_message) => {
                         info!("Received task: {:?}", task_message);

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,7 @@
 use warp::Filter;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use crate::task_recovery_module::{TaskRecoveryManager, Task};
+use crate::task_recovery::{TaskRecoveryManager, Task};
 use uuid::Uuid;
 use warp::http::StatusCode;
 
@@ -64,14 +64,15 @@ async fn get_task_handler(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let task_id = match Uuid::parse_str(&params.task_id) {
         Ok(uuid) => uuid,
-        Err(_) => return Ok(warp::reply::with_status("Invalid UUID", StatusCode::BAD_REQUEST)),
+        Err(_) => return Ok(warp::reply::with_status("Invalid UUID".to_string(), StatusCode::BAD_REQUEST)),
     };
 
     let tasks = task_manager.tasks.read().unwrap();
     if let Some(task) = tasks.get(&task_id) {
-        Ok(warp::reply::json(task))
+        let body = serde_json::to_string(task).unwrap_or_default();
+        Ok(warp::reply::with_status(body, StatusCode::OK))
     } else {
-        Ok(warp::reply::with_status("Task not found", StatusCode::NOT_FOUND))
+        Ok(warp::reply::with_status("Task not found".to_string(), StatusCode::NOT_FOUND))
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,29 @@
+use tokio_postgres::{Client, NoTls, Row, Error};
+use tokio_postgres::types::ToSql;
+use tokio::runtime::Runtime;
+
+pub struct Database {
+    client: Client,
+    rt: Runtime,
+}
+
+impl Database {
+    pub fn connect(conn_str: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let rt = Runtime::new()?;
+        let (client, connection) = rt.block_on(tokio_postgres::connect(conn_str, NoTls))?;
+        rt.spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+        Ok(Database { client, rt })
+    }
+
+    pub fn execute(&self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
+        self.rt.block_on(self.client.execute(query, params))
+    }
+
+    pub fn query(&self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error> {
+        self.rt.block_on(self.client.query(query, params))
+    }
+}

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 use tracing::{info, error};
 use serde::{Deserialize, Serialize};
+use crate::database::Database;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct NodeInfo {
@@ -52,7 +53,7 @@ impl DHT {
 }
 
 // Store DHT in the database
-pub fn store_dht_in_db(dht: &DHT, db: &cockroachdb::Database) -> Result<(), Box<dyn std::error::Error>> {
+pub fn store_dht_in_db(dht: &DHT, db: &Database) -> Result<(), Box<dyn std::error::Error>> {
     let nodes = dht.list_nodes();
     for node in nodes {
         // Serialize NodeInfo and store it in the CockroachDB
@@ -66,7 +67,7 @@ pub fn store_dht_in_db(dht: &DHT, db: &cockroachdb::Database) -> Result<(), Box<
     Ok(())
 }
 
-pub fn load_dht_from_db(db: &cockroachdb::Database) -> Result<DHT, Box<dyn std::error::Error>> {
+pub fn load_dht_from_db(db: &Database) -> Result<DHT, Box<dyn std::error::Error>> {
     let mut dht = DHT::new();
     let rows = db.query("SELECT node_id, node_info FROM dht", &[])?;
     for row in rows {

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -4,6 +4,7 @@ use lapin::{options::*, types::FieldTable, BasicProperties, Connection, Connecti
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use tracing::{error, info};
+use futures_util::stream::StreamExt;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct TaskMessage {
@@ -45,8 +46,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     info!("Ki node is running and waiting for tasks...");
 
-    while let Some(delivery) = consumer.next().await {
-        let (_, delivery) = delivery.expect("error in consumer");
+    while let Some(delivery_result) = consumer.next().await {
+        let delivery = delivery_result?;
         let task_message: TaskMessage = serde_json::from_slice(&delivery.data)?;
 
         info!("Received task: {:?}", task_message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ mod node_registry; // Added node registry module
 mod backup; // Added backup module
 mod api; // Added API module
 mod task_recovery; // Added task recovery module
+mod database; // Database abstraction
+mod dht; // Distributed hash table utilities
 
 #[tokio::main]
 async fn main() {

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -3,6 +3,7 @@ use lapin::{options::*, types::FieldTable, BasicProperties, Connection, Connecti
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use tracing::{error, info};
+use futures_util::stream::StreamExt;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RoleAssignment {
@@ -44,8 +45,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     info!("Principal node is running and waiting for update requests...");
 
-    while let Some(delivery) = consumer.next().await {
-        let (_, delivery) = delivery.expect("error in consumer");
+    while let Some(delivery_result) = consumer.next().await {
+        let delivery = delivery_result?;
         let update_request: UpdateRequest = serde_json::from_slice(&delivery.data)?;
 
         info!("Received update request: {:?}", update_request);


### PR DESCRIPTION
## Summary
- add `tokio-postgres` and supporting crates
- implement `Database` wrapper module
- use `Database` in DHT helpers
- document CockroachDB connection

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_683f43d09a6c83289a458735331f07a9