### PR TITLE
Refactor shared NodeInfo struct

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,11 @@
+use uuid::Uuid;
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NodeInfo {
+    pub id: Uuid,
+    pub address: Option<String>,
+    pub last_seen: Option<DateTime<Utc>>,
+    pub role: String,
+}

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -4,15 +4,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
 use tracing::{info, error};
-use serde::{Deserialize, Serialize};
 use crate::database::Database;
+use crate::common::NodeInfo;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct NodeInfo {
-    id: Uuid,
-    address: String,
-    role: String,
-}
 
 #[derive(Clone)]
 pub struct DHT {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod api; // Added API module
 mod task_recovery; // Added task recovery module
 mod database; // Database abstraction
 mod dht; // Distributed hash table utilities
+mod common; // Shared types
 
 #[tokio::main]
 async fn main() {

--- a/src/node_registry.rs
+++ b/src/node_registry.rs
@@ -3,16 +3,10 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use uuid::Uuid;
-use chrono::{Utc, DateTime};
+use chrono::Utc;
 use tracing::{info, error};
-use std::error::Error;
+use crate::common::NodeInfo;
 
-#[derive(Clone, Debug)]
-pub struct NodeInfo {
-    pub node_id: Uuid,
-    pub last_seen: DateTime<Utc>,
-    pub role: String,
-}
 
 #[derive(Clone)]
 pub struct NodeRegistry {
@@ -28,8 +22,9 @@ impl NodeRegistry {
 
     pub fn register_node(&self, node_id: Uuid, role: String) {
         let node_info = NodeInfo {
-            node_id,
-            last_seen: Utc::now(),
+            id: node_id,
+            address: None,
+            last_seen: Some(Utc::now()),
             role,
         };
         self.nodes.write().unwrap().insert(node_id, node_info.clone());
@@ -39,7 +34,7 @@ impl NodeRegistry {
     pub fn update_last_seen(&self, node_id: &Uuid) {
         let mut nodes = self.nodes.write().unwrap();
         if let Some(node_info) = nodes.get_mut(node_id) {
-            node_info.last_seen = Utc::now();
+            node_info.last_seen = Some(Utc::now());
             info!("Updated last seen for node: {}", node_id);
         } else {
             error!("Attempted to update non-existent node: {}", node_id);


### PR DESCRIPTION
## Summary
- create `src/common.rs` with shared `NodeInfo` definition
- refactor `dht` and `node_registry` to use this struct
- register new module in `main.rs`

## Testing
- `cargo test` *(fails: duplicate key `futures-util` in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68419773f4d08328924cd00bcc6c3ad9