### PR TITLE
Fix Cargo.toml duplicates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,6 @@ config = "0.11"
 
 # Regex for validation
 regex = "1"
-futures-util = "0.3"
-chrono = "0.4"
-base64 = "0.21"
 
 # HMAC and JWT for security
 jsonwebtoken = "8.1"
@@ -52,7 +49,6 @@ aes-gcm = "0.10"
 rand = "0.8"
 
 # Base64 encoding/decoding
-base64 = "0.21"
 
 # Testing framework for lazy static initialization
 lazy_static = "1.4"


### PR DESCRIPTION
## Summary
- remove duplicate futures-util, chrono, and base64 dependencies

## Testing
- `cargo check` *(fails: aes_gcm errors)*

------
https://chatgpt.com/codex/tasks/task_e_68419771de1c8328a522098e2d859add