### PR TITLE
Remove broken architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The system is composed of three main types of nodes:
 
 Inter-node communication is facilitated via RabbitMQ, and tasks are scheduled using a load balancer to optimize resource utilization.
 
-![Architecture Diagram](architecture_diagram.png)
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- remove reference to missing architecture diagram in README

## Testing
- `cargo test` *(fails: use of unresolved module `env`)*

------
https://chatgpt.com/codex/tasks/task_e_686d64cad1a083288a2a7ee01ff592c5