### PR TITLE
Fix aes_gcm error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ regex = "1"
 jsonwebtoken = "8.1"
 hmac = "0.12"
 sha2 = "0.10"
-aes-gcm = "0.10"
+aes-gcm = { version = "0.10", features = ["std"] }
 rand = "0.8"
 
 # Base64 encoding/decoding

--- a/src/security.rs
+++ b/src/security.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use std::error::Error;
+use std::env;
 use tracing::{error, info};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -76,7 +77,9 @@ pub fn encrypt_message(message: &str, key: &str) -> Result<String, Box<dyn Error
     let nonce = Nonce::from_slice(&nonce_bytes);
 
     // Encrypt the message
-    let ciphertext = cipher.encrypt(nonce, message.as_bytes())?;
+    let ciphertext = cipher
+        .encrypt(nonce, message.as_bytes())
+        .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
 
     // Prepend the nonce to the ciphertext so it can be used for decryption
     let mut combined = Vec::with_capacity(nonce_bytes.len() + ciphertext.len());
@@ -104,7 +107,9 @@ pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, Box<d
     let (nonce_bytes, ciphertext) = decoded_bytes.split_at(12);
     let nonce = Nonce::from_slice(nonce_bytes);
 
-    let plaintext = cipher.decrypt(nonce, ciphertext)?;
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|e| Box::<dyn std::error::Error>::from(e))?;
     let decrypted_message = String::from_utf8(plaintext)?;
     Ok(decrypted_message)
 }


### PR DESCRIPTION
## Summary
- import `std::env` in `security.rs`
- enable `aes-gcm`'s `std` feature
- map AES-GCM errors into boxed error types in `encrypt_message` and `decrypt_message`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_686d64c856b88328b7bdaff71fefe5aa