### PR TITLE
Use async DB pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ tokio-postgres = "0.7"
 futures-util = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 base64 = "0.21"
+bb8 = "0.9"
+bb8-postgres = "0.9"
 
 # JSON serialization/deserialization
 serde = { version = "1.0", features = ["derive"] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,29 +1,29 @@
-use tokio_postgres::{Client, NoTls, Row, Error};
+use tokio_postgres::{NoTls, Row, Error};
 use tokio_postgres::types::ToSql;
-use tokio::runtime::Runtime;
+use bb8::{Pool};
+use bb8_postgres::PostgresConnectionManager;
 
 pub struct Database {
-    client: Client,
-    rt: Runtime,
+    pool: Pool<PostgresConnectionManager<NoTls>>,
 }
 
 impl Database {
-    pub fn connect(conn_str: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let rt = Runtime::new()?;
-        let (client, connection) = rt.block_on(tokio_postgres::connect(conn_str, NoTls))?;
-        rt.spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
-            }
-        });
-        Ok(Database { client, rt })
+    pub async fn connect(conn_str: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let config = conn_str.parse()?;
+        let manager = PostgresConnectionManager::new(config, NoTls);
+        let pool = Pool::builder().build(manager).await?;
+        Ok(Database { pool })
     }
 
-    pub fn execute(&self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error> {
-        self.rt.block_on(self.client.execute(query, params))
+    pub async fn execute(&self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Box<dyn std::error::Error>> {
+        let conn = self.pool.get().await.map_err(|e| Box::<dyn std::error::Error>::from(e.to_string()))?;
+        let result = conn.execute(query, params).await?;
+        Ok(result)
     }
 
-    pub fn query(&self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error> {
-        self.rt.block_on(self.client.query(query, params))
+    pub async fn query(&self, query: &str, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Box<dyn std::error::Error>> {
+        let conn = self.pool.get().await.map_err(|e| Box::<dyn std::error::Error>::from(e.to_string()))?;
+        let rows = conn.query(query, params).await?;
+        Ok(rows)
     }
 }

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -47,23 +47,22 @@ impl DHT {
 }
 
 // Store DHT in the database
-pub fn store_dht_in_db(dht: &DHT, db: &Database) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn store_dht_in_db(dht: &DHT, db: &Database) -> Result<(), Box<dyn std::error::Error>> {
     let nodes = dht.list_nodes();
     for node in nodes {
-        // Serialize NodeInfo and store it in the CockroachDB
         let node_id_str = node.id.to_string();
         let serialized_node = serde_json::to_string(&node)?;
         db.execute(
             "INSERT INTO dht (node_id, node_info) VALUES ($1, $2) ON CONFLICT (node_id) DO UPDATE SET node_info = $2",
             &[&node_id_str, &serialized_node],
-        )?;
+        ).await?;
     }
     Ok(())
 }
 
-pub fn load_dht_from_db(db: &Database) -> Result<DHT, Box<dyn std::error::Error>> {
+pub async fn load_dht_from_db(db: &Database) -> Result<DHT, Box<dyn std::error::Error>> {
     let mut dht = DHT::new();
-    let rows = db.query("SELECT node_id, node_info FROM dht", &[])?;
+    let rows = db.query("SELECT node_id, node_info FROM dht", &[]).await?;
     for row in rows {
         let node_id: String = row.get(0);
         let node_info_str: String = row.get(1);

--- a/src/security.rs
+++ b/src/security.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 
 use std::error::Error;
 use tracing::{error, info};
+use std::env;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
@@ -76,7 +77,9 @@ pub fn encrypt_message(message: &str, key: &str) -> Result<String, Box<dyn Error
     let nonce = Nonce::from_slice(&nonce_bytes);
 
     // Encrypt the message
-    let ciphertext = cipher.encrypt(nonce, message.as_bytes())?;
+    let ciphertext = cipher
+        .encrypt(nonce, message.as_bytes())
+        .map_err(|e| Box::<dyn Error>::from(e.to_string()))?;
 
     // Prepend the nonce to the ciphertext so it can be used for decryption
     let mut combined = Vec::with_capacity(nonce_bytes.len() + ciphertext.len());
@@ -104,7 +107,9 @@ pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, Box<d
     let (nonce_bytes, ciphertext) = decoded_bytes.split_at(12);
     let nonce = Nonce::from_slice(nonce_bytes);
 
-    let plaintext = cipher.decrypt(nonce, ciphertext)?;
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|e| Box::<dyn Error>::from(e.to_string()))?;
     let decrypted_message = String::from_utf8(plaintext)?;
     Ok(decrypted_message)
 }


### PR DESCRIPTION
## Summary
- add `bb8` and `bb8-postgres` dependencies for connection pooling
- refactor `Database` to use an async pool
- switch DHT persistence helpers to async
- fix build issues in `security.rs`

## Testing
- `cargo test` *(fails: tests hang beyond 60s)*

------
https://chatgpt.com/codex/tasks/task_e_686d64cd13bc8328a16c74062d55343c