### PR TITLE
Remove duplicate std::env import

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -8,11 +8,10 @@ use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, 
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-
-use std::error::Error;
-use std::env;
 use tracing::{error, info};
+
 use std::env;
+use std::error::Error;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {


### PR DESCRIPTION
## Summary
- clean up security module imports by removing a duplicate `std::env` line and grouping standard library imports together

## Testing
- `cargo test security --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6893c4b57b648328949175e7c821a08b