### PR TITLE
Use Box error for task persistence

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -12,7 +12,6 @@ use sha2::{Digest, Sha256};
 use std::error::Error;
 use std::env;
 use tracing::{error, info};
-use std::env;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
-use std::io::{self, Read, Write};
+use std::io::{Read, Write};
 use std::sync::{Arc, RwLock};
 use tracing::{error, info};
 use uuid::Uuid;
@@ -64,10 +64,13 @@ impl TaskRecoveryManager {
         Ok(())
     }
 
-    fn persist_tasks(&self) -> Result<(), io::Error> {
+    fn persist_tasks(&self) -> Result<(), Box<dyn Error>> {
         let tasks = self.tasks.read().unwrap();
-        let content = serde_json::to_string(&*tasks)?;
-        let mut file = OpenOptions::new().write(true).truncate(true).open(&self.storage_file)?;
+        let content = serde_json::to_string(&*tasks).map_err(|e| Box::<dyn Error>::from(e))?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&self.storage_file)?;
         file.write_all(content.as_bytes())?;
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Use `Box<dyn Error>` as the return type for task persistence
- Clean up duplicate import in security module

## Testing
- `cargo test` *(fails: tests hang after 60s)*

------
https://chatgpt.com/codex/tasks/task_e_6893c4b66c6c83289b1a5eb8da98e922