### PR TITLE
Handle missing task file and add tests

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -12,7 +12,6 @@ use sha2::{Digest, Sha256};
 use std::error::Error;
 use std::env;
 use tracing::{error, info};
-use std::env;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs::{self, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
 use std::sync::{Arc, RwLock};
 use tracing::{error, info};
@@ -51,7 +51,18 @@ impl TaskRecoveryManager {
     }
 
     pub fn recover_tasks(&self) -> Result<(), Box<dyn Error>> {
-        let mut file = OpenOptions::new().read(true).open(&self.storage_file)?;
+        let mut file = match OpenOptions::new().read(true).open(&self.storage_file) {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(&self.storage_file)?;
+                return Ok(());
+            }
+            Err(e) => return Err(Box::new(e)),
+        };
+
         let mut content = String::new();
         file.read_to_string(&mut content)?;
 
@@ -67,7 +78,11 @@ impl TaskRecoveryManager {
     fn persist_tasks(&self) -> Result<(), io::Error> {
         let tasks = self.tasks.read().unwrap();
         let content = serde_json::to_string(&*tasks)?;
-        let mut file = OpenOptions::new().write(true).truncate(true).open(&self.storage_file)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&self.storage_file)?;
         file.write_all(content.as_bytes())?;
         Ok(())
     }
@@ -99,6 +114,19 @@ mod tests {
         assert!(new_recovery_manager.tasks.read().unwrap().contains_key(&task.task_id));
 
         // Clean up test file
+        fs::remove_file(storage_file).unwrap();
+    }
+
+    #[test]
+    fn test_recover_tasks_file_absent() {
+        let storage_file = "missing_tasks.json";
+        if fs::metadata(storage_file).is_ok() {
+            fs::remove_file(storage_file).unwrap();
+        }
+        let recovery_manager = TaskRecoveryManager::new(storage_file);
+        assert!(recovery_manager.recover_tasks().is_ok());
+        assert!(fs::metadata(storage_file).is_ok());
+        assert!(recovery_manager.tasks.read().unwrap().is_empty());
         fs::remove_file(storage_file).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- Gracefully handle missing task storage by creating an empty file or skipping recovery
- Ensure tasks are persisted even if the storage file is absent
- Add unit test for recovery when the file is missing
- Remove duplicate `env` import in security module

## Testing
- `cargo test` *(hung: api::tests::test_add_task, api::tests::test_delete_task, api::tests::test_get_task, task_recovery::tests::test_task_recovery)*
- `cargo test task_recovery::tests:: -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6893c4b7b8b08328bfed1d2227096dc3