### PR TITLE
Use tokio RwLock in core components

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -67,7 +67,7 @@ async fn get_task_handler(
         Err(_) => return Ok(warp::reply::with_status("Invalid UUID".to_string(), StatusCode::BAD_REQUEST)),
     };
 
-    let tasks = task_manager.tasks.read().unwrap();
+    let tasks = task_manager.tasks.read().await;
     if let Some(task) = tasks.get(&task_id) {
         let body = serde_json::to_string(task).unwrap_or_default();
         Ok(warp::reply::with_status(body, StatusCode::OK))
@@ -80,7 +80,7 @@ async fn add_task_handler(
     task_manager: Arc<TaskRecoveryManager>,
     new_task: Task,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    task_manager.add_task(new_task);
+    task_manager.add_task(new_task).await;
     Ok(warp::reply::with_status("Task added", StatusCode::CREATED))
 }
 
@@ -93,7 +93,7 @@ async fn delete_task_handler(
         Err(_) => return Ok(warp::reply::with_status("Invalid UUID", StatusCode::BAD_REQUEST)),
     };
 
-    task_manager.remove_task(&task_id);
+    task_manager.remove_task(&task_id).await;
     Ok(warp::reply::with_status("Task deleted", StatusCode::OK))
 }
 
@@ -132,7 +132,7 @@ mod tests {
             task_id: Uuid::new_v4(),
             data: "Test task data".to_string(),
         };
-        task_manager.add_task(task.clone());
+        task_manager.add_task(task.clone()).await;
 
         let res = request()
             .method("GET")
@@ -152,7 +152,7 @@ mod tests {
             task_id: Uuid::new_v4(),
             data: "Test task data".to_string(),
         };
-        task_manager.add_task(task.clone());
+        task_manager.add_task(task.clone()).await;
 
         let res = request()
             .method("DELETE")

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -1,7 +1,8 @@
 // dht.rs: Implements a distributed hash table (DHT) for node discovery and coordination.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use uuid::Uuid;
 use tracing::{info, error};
 use crate::database::Database;
@@ -20,14 +21,14 @@ impl DHT {
         }
     }
 
-    pub fn add_node(&self, node_info: NodeInfo) {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn add_node(&self, node_info: NodeInfo) {
+        let mut nodes = self.nodes.write().await;
         nodes.insert(node_info.id, node_info.clone());
         info!("Added node to DHT: {:?}", node_info);
     }
 
-    pub fn remove_node(&self, node_id: &Uuid) {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn remove_node(&self, node_id: &Uuid) {
+        let mut nodes = self.nodes.write().await;
         if nodes.remove(node_id).is_some() {
             info!("Removed node from DHT: {:?}", node_id);
         } else {
@@ -35,20 +36,20 @@ impl DHT {
         }
     }
 
-    pub fn get_node(&self, node_id: &Uuid) -> Option<NodeInfo> {
-        let nodes = self.nodes.read().unwrap();
+    pub async fn get_node(&self, node_id: &Uuid) -> Option<NodeInfo> {
+        let nodes = self.nodes.read().await;
         nodes.get(node_id).cloned()
     }
 
-    pub fn list_nodes(&self) -> Vec<NodeInfo> {
-        let nodes = self.nodes.read().unwrap();
+    pub async fn list_nodes(&self) -> Vec<NodeInfo> {
+        let nodes = self.nodes.read().await;
         nodes.values().cloned().collect()
     }
 }
 
 // Store DHT in the database
 pub async fn store_dht_in_db(dht: &DHT, db: &Database) -> Result<(), Box<dyn std::error::Error>> {
-    let nodes = dht.list_nodes();
+    let nodes = dht.list_nodes().await;
     for node in nodes {
         let node_id_str = node.id.to_string();
         let serialized_node = serde_json::to_string(&node)?;
@@ -61,13 +62,13 @@ pub async fn store_dht_in_db(dht: &DHT, db: &Database) -> Result<(), Box<dyn std
 }
 
 pub async fn load_dht_from_db(db: &Database) -> Result<DHT, Box<dyn std::error::Error>> {
-    let mut dht = DHT::new();
+    let dht = DHT::new();
     let rows = db.query("SELECT node_id, node_info FROM dht", &[]).await?;
     for row in rows {
         let _node_id: String = row.get(0);
         let node_info_str: String = row.get(1);
         let node_info: NodeInfo = serde_json::from_str(&node_info_str)?;
-        dht.add_node(node_info);
+        dht.add_node(node_info).await;
     }
     Ok(dht)
 }

--- a/src/load_balancer.rs
+++ b/src/load_balancer.rs
@@ -1,7 +1,8 @@
 // load_balancer.rs: Implements load balancing for An nodes to effectively distribute tasks.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use uuid::Uuid;
 use tokio::sync::broadcast;
 use tracing::{info, error};
@@ -25,14 +26,14 @@ impl LoadBalancer {
         }
     }
 
-    pub fn add_node(&self, node_id: Uuid) {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn add_node(&self, node_id: Uuid) {
+        let mut nodes = self.nodes.write().await;
         nodes.insert(node_id, NodeLoadInfo { node_id, task_count: 0 });
         info!("Added node to load balancer: {}", node_id);
     }
 
-    pub fn remove_node(&self, node_id: &Uuid) {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn remove_node(&self, node_id: &Uuid) {
+        let mut nodes = self.nodes.write().await;
         if nodes.remove(node_id).is_some() {
             info!("Removed node from load balancer: {}", node_id);
         } else {
@@ -40,8 +41,8 @@ impl LoadBalancer {
         }
     }
 
-    pub fn assign_task(&self) -> Option<Uuid> {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn assign_task(&self) -> Option<Uuid> {
+        let mut nodes = self.nodes.write().await;
         if nodes.is_empty() {
             error!("No nodes available to assign task.");
             return None;
@@ -57,8 +58,8 @@ impl LoadBalancer {
         }
     }
 
-    pub fn complete_task(&self, node_id: &Uuid) {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn complete_task(&self, node_id: &Uuid) {
+        let mut nodes = self.nodes.write().await;
         if let Some(node_info) = nodes.get_mut(node_id) {
             if node_info.task_count > 0 {
                 node_info.task_count -= 1;
@@ -69,15 +70,15 @@ impl LoadBalancer {
         }
     }
 
-    pub fn random_node(&self) -> Option<Uuid> {
-        let nodes = self.nodes.read().unwrap();
+    pub async fn random_node(&self) -> Option<Uuid> {
+        let nodes = self.nodes.read().await;
         nodes.keys().cloned().choose(&mut rand::thread_rng())
     }
 }
 
 pub async fn monitor_node_load(mut rx: broadcast::Receiver<NodeLoadInfo>, load_balancer: LoadBalancer) {
     while let Ok(node_load) = rx.recv().await {
-        let mut nodes = load_balancer.nodes.write().unwrap();
+        let mut nodes = load_balancer.nodes.write().await;
         if let Some(node_info) = nodes.get_mut(&node_load.node_id) {
             node_info.task_count = node_load.task_count;
             info!("Updated load info for node: {}. Task count: {}", node_load.node_id, node_load.task_count);

--- a/src/node_registry.rs
+++ b/src/node_registry.rs
@@ -1,7 +1,8 @@
 // node_registry.rs: Implements a node registry for keeping track of active nodes in the distributed neural network system.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use uuid::Uuid;
 use chrono::Utc;
 use tracing::{info, error};
@@ -20,19 +21,19 @@ impl NodeRegistry {
         }
     }
 
-    pub fn register_node(&self, node_id: Uuid, role: String) {
+    pub async fn register_node(&self, node_id: Uuid, role: String) {
         let node_info = NodeInfo {
             id: node_id,
             address: None,
             last_seen: Some(Utc::now()),
             role,
         };
-        self.nodes.write().unwrap().insert(node_id, node_info.clone());
+        self.nodes.write().await.insert(node_id, node_info.clone());
         info!("Registered new node: {:?}", node_info);
     }
 
-    pub fn update_last_seen(&self, node_id: &Uuid) {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn update_last_seen(&self, node_id: &Uuid) {
+        let mut nodes = self.nodes.write().await;
         if let Some(node_info) = nodes.get_mut(node_id) {
             node_info.last_seen = Some(Utc::now());
             info!("Updated last seen for node: {}", node_id);
@@ -41,8 +42,8 @@ impl NodeRegistry {
         }
     }
 
-    pub fn remove_node(&self, node_id: &Uuid) {
-        let mut nodes = self.nodes.write().unwrap();
+    pub async fn remove_node(&self, node_id: &Uuid) {
+        let mut nodes = self.nodes.write().await;
         if nodes.remove(node_id).is_some() {
             info!("Removed node from registry: {}", node_id);
         } else {
@@ -50,13 +51,13 @@ impl NodeRegistry {
         }
     }
 
-    pub fn list_active_nodes(&self) -> Vec<NodeInfo> {
-        let nodes = self.nodes.read().unwrap();
+    pub async fn list_active_nodes(&self) -> Vec<NodeInfo> {
+        let nodes = self.nodes.read().await;
         nodes.values().cloned().collect()
     }
 
-    pub fn get_node_info(&self, node_id: &Uuid) -> Option<NodeInfo> {
-        let nodes = self.nodes.read().unwrap();
+    pub async fn get_node_info(&self, node_id: &Uuid) -> Option<NodeInfo> {
+        let nodes = self.nodes.read().await;
         nodes.get(node_id).cloned()
     }
 }
@@ -65,43 +66,47 @@ impl NodeRegistry {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_register_and_update_node() {
+    #[tokio::test]
+    async fn test_register_and_update_node() {
         let registry = NodeRegistry::new();
         let node_id = Uuid::new_v4();
         let role = "teacher".to_string();
 
-        registry.register_node(node_id, role.clone());
-        assert!(registry.get_node_info(&node_id).is_some());
+        registry.register_node(node_id, role.clone()).await;
+        assert!(registry.get_node_info(&node_id).await.is_some());
 
-        registry.update_last_seen(&node_id);
-        let node_info = registry.get_node_info(&node_id).unwrap();
+        registry.update_last_seen(&node_id).await;
+        let node_info = registry.get_node_info(&node_id).await.unwrap();
         assert_eq!(node_info.role, role);
     }
 
-    #[test]
-    fn test_remove_node() {
+    #[tokio::test]
+    async fn test_remove_node() {
         let registry = NodeRegistry::new();
         let node_id = Uuid::new_v4();
         let role = "ki".to_string();
 
-        registry.register_node(node_id, role);
-        assert!(registry.get_node_info(&node_id).is_some());
+        registry.register_node(node_id, role).await;
+        assert!(registry.get_node_info(&node_id).await.is_some());
 
-        registry.remove_node(&node_id);
-        assert!(registry.get_node_info(&node_id).is_none());
+        registry.remove_node(&node_id).await;
+        assert!(registry.get_node_info(&node_id).await.is_none());
     }
 
-    #[test]
-    fn test_list_active_nodes() {
+    #[tokio::test]
+    async fn test_list_active_nodes() {
         let registry = NodeRegistry::new();
         let node_id_1 = Uuid::new_v4();
         let node_id_2 = Uuid::new_v4();
 
-        registry.register_node(node_id_1, "teacher".to_string());
-        registry.register_node(node_id_2, "ki".to_string());
+        registry
+            .register_node(node_id_1, "teacher".to_string())
+            .await;
+        registry
+            .register_node(node_id_2, "ki".to_string())
+            .await;
 
-        let active_nodes = registry.list_active_nodes();
+        let active_nodes = registry.list_active_nodes().await;
         assert_eq!(active_nodes.len(), 2);
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -28,7 +28,7 @@ impl Scheduler {
     }
 
     pub async fn schedule_task(&self, task: Task) -> Result<(), Box<dyn Error>> {
-        if let Some(node_id) = self.load_balancer.assign_task() {
+        if let Some(node_id) = self.load_balancer.assign_task().await {
             info!("Scheduling task {} to node {}", task.task_id, node_id);
             self.task_tx.send(task).await?;
             Ok(())
@@ -67,7 +67,7 @@ mod tests {
         let (task_tx, mut task_rx) = mpsc::channel(10);
         let scheduler = Scheduler::new(load_balancer.clone(), task_tx);
 
-        load_balancer.add_node(Uuid::new_v4());
+        load_balancer.add_node(Uuid::new_v4()).await;
         let task = Task {
             task_id: Uuid::new_v4(),
             data: "Test data".to_string(),

--- a/src/security.rs
+++ b/src/security.rs
@@ -12,7 +12,6 @@ use sha2::{Digest, Sha256};
 use std::error::Error;
 use std::env;
 use tracing::{error, info};
-use std::env;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use tracing::{error, info};
 use uuid::Uuid;
 use std::error::Error;
@@ -29,20 +30,20 @@ impl TaskRecoveryManager {
         }
     }
 
-    pub fn add_task(&self, task: Task) {
-        let mut tasks = self.tasks.write().unwrap();
+    pub async fn add_task(&self, task: Task) {
+        let mut tasks = self.tasks.write().await;
         tasks.insert(task.task_id, task.clone());
         info!("Added task to recovery manager: {:?}", task);
-        if let Err(e) = self.persist_tasks() {
+        if let Err(e) = self.persist_tasks().await {
             error!("Failed to persist tasks: {:?}", e);
         }
     }
 
-    pub fn remove_task(&self, task_id: &Uuid) {
-        let mut tasks = self.tasks.write().unwrap();
+    pub async fn remove_task(&self, task_id: &Uuid) {
+        let mut tasks = self.tasks.write().await;
         if tasks.remove(task_id).is_some() {
             info!("Removed task from recovery manager: {}", task_id);
-            if let Err(e) = self.persist_tasks() {
+            if let Err(e) = self.persist_tasks().await {
                 error!("Failed to persist tasks: {:?}", e);
             }
         } else {
@@ -50,22 +51,22 @@ impl TaskRecoveryManager {
         }
     }
 
-    pub fn recover_tasks(&self) -> Result<(), Box<dyn Error>> {
+    pub async fn recover_tasks(&self) -> Result<(), Box<dyn Error>> {
         let mut file = OpenOptions::new().read(true).open(&self.storage_file)?;
         let mut content = String::new();
         file.read_to_string(&mut content)?;
 
         if !content.is_empty() {
             let recovered_tasks: HashMap<Uuid, Task> = serde_json::from_str(&content)?;
-            let mut tasks = self.tasks.write().unwrap();
+            let mut tasks = self.tasks.write().await;
             *tasks = recovered_tasks;
             info!("Recovered tasks from storage file.");
         }
         Ok(())
     }
 
-    fn persist_tasks(&self) -> Result<(), io::Error> {
-        let tasks = self.tasks.read().unwrap();
+    async fn persist_tasks(&self) -> Result<(), io::Error> {
+        let tasks = self.tasks.read().await;
         let content = serde_json::to_string(&*tasks)?;
         let mut file = OpenOptions::new().write(true).truncate(true).open(&self.storage_file)?;
         file.write_all(content.as_bytes())?;
@@ -78,8 +79,8 @@ mod tests {
     use super::*;
     use std::fs;
 
-    #[test]
-    fn test_task_recovery() {
+    #[tokio::test]
+    async fn test_task_recovery() {
         let storage_file = "test_tasks.json";
         let recovery_manager = TaskRecoveryManager::new(storage_file);
 
@@ -88,15 +89,15 @@ mod tests {
             data: "Test data".to_string(),
         };
 
-        recovery_manager.add_task(task.clone());
-        recovery_manager.remove_task(&task.task_id);
+        recovery_manager.add_task(task.clone()).await;
+        recovery_manager.remove_task(&task.task_id).await;
 
         // Recover tasks from file
-        recovery_manager.add_task(task.clone());
-        recovery_manager.persist_tasks().unwrap();
+        recovery_manager.add_task(task.clone()).await;
+        recovery_manager.persist_tasks().await.unwrap();
         let new_recovery_manager = TaskRecoveryManager::new(storage_file);
-        new_recovery_manager.recover_tasks().unwrap();
-        assert!(new_recovery_manager.tasks.read().unwrap().contains_key(&task.task_id));
+        new_recovery_manager.recover_tasks().await.unwrap();
+        assert!(new_recovery_manager.tasks.read().await.contains_key(&task.task_id));
 
         // Clean up test file
         fs::remove_file(storage_file).unwrap();

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -19,13 +19,19 @@ async fn test_task_recovery_persistence() {
     };
 
     // Add task and persist to file
-    recovery_manager.add_task(task.clone());
-    recovery_manager.persist_tasks().unwrap();
+    recovery_manager.add_task(task.clone()).await;
+    recovery_manager.persist_tasks().await.unwrap();
 
     // Create a new recovery manager to test loading from the persisted file
     let new_recovery_manager = TaskRecoveryManager::new(storage_file);
-    new_recovery_manager.recover_tasks().unwrap();
-    assert!(new_recovery_manager.tasks.read().unwrap().contains_key(&task.task_id));
+    new_recovery_manager.recover_tasks().await.unwrap();
+    assert!(
+        new_recovery_manager
+            .tasks
+            .read()
+            .await
+            .contains_key(&task.task_id)
+    );
 
     // Clean up test file
     std::fs::remove_file(storage_file).unwrap();
@@ -73,7 +79,7 @@ async fn test_task_api_delete() {
         task_id: Uuid::new_v4(),
         data: "Delete test task data".to_string(),
     };
-    task_manager.add_task(task.clone());
+    task_manager.add_task(task.clone()).await;
 
     // Test deleting the task
     let res = request()
@@ -106,16 +112,22 @@ async fn test_recovery_after_crash() {
     };
 
     // Simulate adding a task and persisting before a crash
-    recovery_manager.add_task(task.clone());
-    recovery_manager.persist_tasks().unwrap();
+    recovery_manager.add_task(task.clone()).await;
+    recovery_manager.persist_tasks().await.unwrap();
 
     // Simulate a delay (representing downtime)
     sleep(Duration::from_secs(1)).await;
 
     // Recover tasks after "crash"
     let new_recovery_manager = TaskRecoveryManager::new(storage_file);
-    new_recovery_manager.recover_tasks().unwrap();
-    assert!(new_recovery_manager.tasks.read().unwrap().contains_key(&task.task_id));
+    new_recovery_manager.recover_tasks().await.unwrap();
+    assert!(
+        new_recovery_manager
+            .tasks
+            .read()
+            .await
+            .contains_key(&task.task_id)
+    );
 
     // Clean up test file
     std::fs::remove_file(storage_file).unwrap();


### PR DESCRIPTION
## Summary
- refactor DHT to use async `tokio::sync::RwLock`
- switch NodeRegistry and LoadBalancer to async lock API
- migrate TaskRecoveryManager to tokio RwLock and awaiters

## Testing
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_e_6893c4b992288328b2741e17c1b75d64