### PR TITLE
refactor: unify Task struct

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,7 +1,8 @@
 // api.rs: Implements REST API endpoints for interacting with the task recovery system.
 
-use crate::task_recovery::{Task, TaskRecoveryManager};
-use serde::{Deserialize, Serialize};
+use crate::task_recovery::TaskRecoveryManager;
+use crate::common::Task;
+use serde::Deserialize;
 use std::sync::Arc;
 use uuid::Uuid;
 use warp::http::StatusCode;

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,6 +1,6 @@
 // backup.rs: Implements a backup mechanism for task persistence to enhance robustness and redundancy.
 
-use serde::{Deserialize, Serialize};
+use crate::common::Task;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::sync::{Arc, RwLock};
@@ -10,12 +10,6 @@ use uuid::Uuid;
 use chrono::Utc;
 use std::error::Error;
 use std::path::Path;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Task {
-    pub task_id: Uuid,
-    pub data: String,
-}
 
 #[derive(Clone)]
 pub struct BackupManager {

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,6 +3,12 @@ use serde::{Serialize, Deserialize};
 use chrono::{DateTime, Utc};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Task {
+    pub task_id: Uuid,
+    pub data: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeInfo {
     pub id: Uuid,
     pub address: Option<String>,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,18 +1,13 @@
 // scheduler.rs: Implements a task scheduler that assigns tasks to Ki nodes based on load and capacity.
 
 use crate::load_balancer::LoadBalancer;
+use crate::common::Task;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 use tracing::{info, error};
 use std::time::Duration;
 use tokio::time;
 use std::error::Error;
-
-#[derive(Clone, Debug)]
-pub struct Task {
-    pub task_id: Uuid,
-    pub data: String,
-}
 
 pub struct Scheduler {
     load_balancer: LoadBalancer,

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -1,20 +1,14 @@
 // task_recovery.rs: Implements task persistence and recovery for robustness.
 
-use serde::{Deserialize, Serialize};
+use crate::common::Task;
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 use uuid::Uuid;
 use std::error::Error;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Task {
-    pub task_id: Uuid,
-    pub data: String,
-}
 
 #[derive(Clone)]
 pub struct TaskRecoveryManager {
@@ -51,7 +45,7 @@ impl TaskRecoveryManager {
         }
     }
 
-    pub fn recover_tasks(&self) -> Result<(), Box<dyn Error>> {
+    pub async fn recover_tasks(&self) -> Result<(), Box<dyn Error>> {
         let mut file = match OpenOptions::new().read(true).open(&self.storage_file) {
             Ok(f) => f,
             Err(e) if e.kind() == io::ErrorKind::NotFound => {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,6 +1,7 @@
 // testing.rs: Implements integration tests for the distributed neural network system.
 
-use crate::task_recovery::{TaskRecoveryManager, Task};
+use crate::task_recovery::TaskRecoveryManager;
+use crate::common::Task;
 use crate::api::Api;
 use std::sync::Arc;
 use uuid::Uuid;


### PR DESCRIPTION
## Summary
- define shared `Task` struct in `common` module
- refactor scheduler, task recovery, backup, API and tests to use the shared type
- fix `recover_tasks` to be async

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_689d229d0ec48328a7752f95eafdf28e