### PR TITLE
Use tokio RwLock for task recovery

### DIFF
--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -2,13 +2,13 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::error::Error;
 use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 use uuid::Uuid;
-use std::error::Error;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Task {
@@ -51,7 +51,7 @@ impl TaskRecoveryManager {
         }
     }
 
-    pub fn recover_tasks(&self) -> Result<(), Box<dyn Error>> {
+    pub async fn recover_tasks(&self) -> Result<(), Box<dyn Error>> {
         let mut file = match OpenOptions::new().read(true).open(&self.storage_file) {
             Ok(f) => f,
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
@@ -76,7 +76,7 @@ impl TaskRecoveryManager {
         Ok(())
     }
 
-    async fn persist_tasks(&self) -> Result<(), io::Error> {
+    async fn persist_tasks(&self) -> Result<(), Box<dyn Error>> {
         let tasks = self.tasks.read().await;
         let content = serde_json::to_string(&*tasks)?;
         let mut file = OpenOptions::new()
@@ -112,22 +112,26 @@ mod tests {
         recovery_manager.persist_tasks().await.unwrap();
         let new_recovery_manager = TaskRecoveryManager::new(storage_file);
         new_recovery_manager.recover_tasks().await.unwrap();
-        assert!(new_recovery_manager.tasks.read().await.contains_key(&task.task_id));
+        assert!(new_recovery_manager
+            .tasks
+            .read()
+            .await
+            .contains_key(&task.task_id));
 
         // Clean up test file
         fs::remove_file(storage_file).unwrap();
     }
 
-    #[test]
-    fn test_recover_tasks_file_absent() {
+    #[tokio::test]
+    async fn test_recover_tasks_file_absent() {
         let storage_file = "missing_tasks.json";
         if fs::metadata(storage_file).is_ok() {
             fs::remove_file(storage_file).unwrap();
         }
         let recovery_manager = TaskRecoveryManager::new(storage_file);
-        assert!(recovery_manager.recover_tasks().is_ok());
+        assert!(recovery_manager.recover_tasks().await.is_ok());
         assert!(fs::metadata(storage_file).is_ok());
-        assert!(recovery_manager.tasks.read().unwrap().is_empty());
+        assert!(recovery_manager.tasks.read().await.is_empty());
         fs::remove_file(storage_file).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- switch task recovery manager to tokio's `RwLock`
- make `recover_tasks` async and propagate serde errors from `persist_tasks`
- update tests to await `RwLock` access

## Testing
- `cargo test`
- `cargo test task_recovery::tests::test_recover_tasks_file_absent`

------
https://chatgpt.com/codex/tasks/task_e_689d22a1ecb48328a83536d90773e5a0