### PR TITLE
Expose JWT claim structure in auth and security modules

### DIFF
--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -7,10 +7,10 @@ use std::env;
 use tracing::{info, error};
 
 #[derive(Debug, Serialize, Deserialize)]
-struct Claims {
-    sub: String,  // Subject (usually the node ID)
-    role: String, // Role of the node (e.g., principal, teacher, ki)
-    exp: usize,   // Expiration time as a UNIX timestamp
+pub struct Claims {
+    pub sub: String,  // Subject (usually the node ID)
+    pub role: String, // Role of the node (e.g., principal, teacher, ki)
+    pub exp: usize,   // Expiration time as a UNIX timestamp
 }
 
 fn get_secret_key() -> Result<String, env::VarError> {
@@ -67,4 +67,32 @@ pub fn renew_token(token: &str, new_expiration: usize) -> Result<String, Box<dyn
     let new_token = encode(&Header::default(), &token_data, &EncodingKey::from_secret(secret_key.as_ref()))?;
     info!("Renewed token for node_id: {} with new expiration: {}", token_data.sub, new_expiration);
     Ok(new_token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generate_token, renew_token, verify_token};
+
+    #[test]
+    fn test_generate_and_verify_token() {
+        std::env::set_var("JWT_SECRET_KEY", "test_secret_key");
+        let node_id = "test_node";
+        let role = "teacher";
+        let token = generate_token(node_id, role, 60).unwrap();
+        let token_data = verify_token(&token).unwrap();
+        assert_eq!(token_data.claims.sub, node_id);
+        assert_eq!(token_data.claims.role, role);
+    }
+
+    #[test]
+    fn test_renew_token() {
+        std::env::set_var("JWT_SECRET_KEY", "test_secret_key");
+        let node_id = "test_node";
+        let role = "teacher";
+        let token = generate_token(node_id, role, 60).unwrap();
+        let new_exp = 120;
+        let new_token = renew_token(&token, new_exp).unwrap();
+        let token_data = verify_token(&new_token).unwrap();
+        assert_eq!(token_data.claims.exp, new_exp);
+    }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -14,10 +14,10 @@ use std::error::Error;
 use tracing::{error, info};
 
 #[derive(Debug, Serialize, Deserialize)]
-struct Claims {
-    sub: String,  // Subject (usually the node ID)
-    role: String, // Role of the node (e.g., principal, teacher, ki)
-    exp: usize,   // Expiration time as a UNIX timestamp
+pub struct Claims {
+    pub sub: String,  // Subject (usually the node ID)
+    pub role: String, // Role of the node (e.g., principal, teacher, ki)
+    pub exp: usize,   // Expiration time as a UNIX timestamp
 }
 
 fn get_secret_key() -> Result<String, env::VarError> {
@@ -116,7 +116,9 @@ pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, Box<d
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{
+        encrypt_message, decrypt_message, generate_token, verify_token, Claims,
+    };
 
     #[test]
     fn test_generate_and_verify_token() {
@@ -125,9 +127,10 @@ mod tests {
         let role = "teacher";
         let token = generate_token(node_id, role, 60).unwrap();
         let token_data = verify_token(&token).unwrap();
+        let Claims { sub, role: claim_role, .. } = token_data.claims;
 
-        assert_eq!(token_data.claims.sub, node_id);
-        assert_eq!(token_data.claims.role, role);
+        assert_eq!(sub, node_id);
+        assert_eq!(claim_role, role);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make JWT `Claims` struct and fields public
- update auth/security tests to use public claims

## Testing
- `cargo test` *(fails: RwLock reimported and non-future await in task_recovery.rs)*

------
https://chatgpt.com/codex/tasks/task_e_689d22a06ae88328b475aa40971bb3dd