### PR TITLE
Fix build failure from private Task import

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 // api.rs: Implements REST API endpoints for interacting with the task recovery system.
 
-use crate::task_recovery::{Task, TaskRecoveryManager};
+use crate::task_recovery::TaskRecoveryManager;
 use crate::common::Task;
 use serde::Deserialize;
 use std::sync::Arc;


### PR DESCRIPTION
## Summary
- Avoid importing `Task` through `task_recovery` and import it directly from `common` in the API module

## Testing
- `cargo build`
- `cargo test` *(hangs: `test api::tests::test_add_task has been running for over 60 seconds`)*

------
https://chatgpt.com/codex/tasks/task_e_689fb1ce708c832892caf1a123c4eb1f