### PR TITLE
Add default configuration and loader fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ out/
 .env
 /config/*.json
 /config/*.toml
+!config/default.toml
 
 # Ignore Python bytecode files (if any)
 *.pyc

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,0 +1,6 @@
+# Example configuration for the distributed neural network system
+# Copy this file to `config/default.toml` and adjust values as needed
+
+amqp_addr = "amqp://127.0.0.1:5672/%2f"
+jwt_secret_key = "<JWT_SECRET_KEY>"
+database_url = "postgresql://root@localhost:26257/defaultdb?sslmode=disable"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
 // config.rs: Centralizes configuration settings for the distributed neural network.
 
-use config::{Config, ConfigError, Environment, File};
+use config::{Config, ConfigError, Environment, File, FileFormat};
 use serde::Deserialize;
 use std::env;
+use std::path::Path;
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
@@ -15,8 +16,13 @@ impl Settings {
     pub fn new() -> Result<Self, ConfigError> {
         let mut s = Config::new();
 
-        // Start with a default configuration file
-        s.merge(File::with_name("config/default"))?;
+        // Start with a default configuration file. Prefer `default.toml`,
+        // but fall back to `default.example` if the former is missing.
+        if Path::new("config/default.toml").exists() {
+            s.merge(File::with_name("config/default"))?;
+        } else {
+            s.merge(File::new("config/default.example", FileFormat::Toml))?;
+        }
 
         // Add in environment-specific settings
         let env = env::var("RUN_ENV").unwrap_or_else(|_| "development".into());


### PR DESCRIPTION
## Summary
- track a sample `config/default.toml`
- load `config/default.example` when `default.toml` is missing

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_689fbc48c6c0832889b461b5d28a2180