### PR TITLE
Use tokio RwLock for async state management

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,8 +1,8 @@
 // consensus.rs: Implements a consensus algorithm to ensure consistency across An nodes.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
-use tokio::sync::{broadcast, mpsc};
+use std::sync::Arc;
+use tokio::sync::{broadcast, mpsc, RwLock};
 use uuid::Uuid;
 use tracing::{info, error};
 use std::error::Error;
@@ -29,15 +29,15 @@ impl ConsensusState {
         }
     }
 
-    pub fn add_proposal(&self, proposal: ConsensusProposal) {
-        let mut proposals = self.proposals.write().unwrap();
+    pub async fn add_proposal(&self, proposal: ConsensusProposal) {
+        let mut proposals = self.proposals.write().await;
         proposals.insert(proposal.proposal_id, proposal.clone());
-        self.votes.write().unwrap().insert(proposal.proposal_id, 0);
+        self.votes.write().await.insert(proposal.proposal_id, 0);
         info!("Added new proposal: {:?}", proposal);
     }
 
-    pub fn cast_vote(&self, proposal_id: Uuid) {
-        let mut votes = self.votes.write().unwrap();
+    pub async fn cast_vote(&self, proposal_id: Uuid) {
+        let mut votes = self.votes.write().await;
         if let Some(vote_count) = votes.get_mut(&proposal_id) {
             *vote_count += 1;
             info!("Cast vote for proposal: {}. Current votes: {}", proposal_id, *vote_count);
@@ -46,8 +46,8 @@ impl ConsensusState {
         }
     }
 
-    pub fn has_consensus(&self, proposal_id: Uuid, threshold: usize) -> bool {
-        let votes = self.votes.read().unwrap();
+    pub async fn has_consensus(&self, proposal_id: Uuid, threshold: usize) -> bool {
+        let votes = self.votes.read().await;
         if let Some(&vote_count) = votes.get(&proposal_id) {
             vote_count >= threshold
         } else {
@@ -65,11 +65,11 @@ pub async fn run_consensus_protocol(
     loop {
         tokio::select! {
             Some(proposal) = proposal_rx.recv() => {
-                consensus_state.add_proposal(proposal);
+                consensus_state.add_proposal(proposal).await;
             }
             Ok(proposal_id) = vote_rx.recv() => {
-                consensus_state.cast_vote(proposal_id);
-                if consensus_state.has_consensus(proposal_id, consensus_threshold) {
+                consensus_state.cast_vote(proposal_id).await;
+                if consensus_state.has_consensus(proposal_id, consensus_threshold).await {
                     info!("Consensus reached for proposal: {}", proposal_id);
                     // Handle the proposal that reached consensus (e.g., apply an update to the database)
                 }

--- a/src/election.rs
+++ b/src/election.rs
@@ -1,7 +1,7 @@
 // election.rs: Implements leader election for An nodes to ensure redundancy and high availability.
 
-use std::sync::{Arc, RwLock};
-use tokio::sync::broadcast;
+use std::sync::Arc;
+use tokio::sync::{broadcast, RwLock};
 use tokio::time::{self, Duration};
 use uuid::Uuid;
 use tracing::{info, error};
@@ -32,16 +32,16 @@ impl Election {
         }
     }
 
-    pub fn start_election(&self) {
-        let mut node_status = self.node_status.write().unwrap();
+    pub async fn start_election(&self) {
+        let mut node_status = self.node_status.write().await;
         node_status.is_candidate = true;
         info!("Node {} is starting an election as a candidate.", node_status.node_id);
     }
 
-    pub fn set_leader(&self, leader_id: Uuid) {
-        let mut current_leader = self.current_leader.write().unwrap();
+    pub async fn set_leader(&self, leader_id: Uuid) {
+        let mut current_leader = self.current_leader.write().await;
         *current_leader = Some(leader_id);
-        let mut node_status = self.node_status.write().unwrap();
+        let mut node_status = self.node_status.write().await;
         node_status.is_leader = node_status.node_id == leader_id;
         node_status.is_candidate = false;
         info!("Node {} is now the leader: {}", node_status.node_id, node_status.is_leader);
@@ -54,16 +54,16 @@ pub async fn run_leader_election(election: Election, mut rx: broadcast::Receiver
     loop {
         tokio::select! {
             _ = ticker.tick() => {
-                let current_leader = election.current_leader.read().unwrap();
+                let current_leader = election.current_leader.read().await;
                 if current_leader.is_none() {
                     info!("No current leader. Initiating a new election.");
-                    election.start_election();
+                    election.start_election().await;
                     // Broadcast the candidacy and handle the election logic (e.g., majority vote)
                 }
             }
             Ok(node_status) = rx.recv() => {
                 if node_status.is_leader {
-                    election.set_leader(node_status.node_id);
+                    election.set_leader(node_status.node_id).await;
                 }
             }
             Err(e) => {

--- a/src/network.rs
+++ b/src/network.rs
@@ -5,7 +5,8 @@ use tokio::time::{timeout, Duration};
 use tracing::{info, error};
 use std::error::Error;
 use std::net::SocketAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use std::collections::HashSet;
 
 #[derive(Clone, Debug)]
@@ -25,7 +26,7 @@ impl NetworkManager {
             match timeout(timeout_duration, TcpStream::connect(address)).await {
                 Ok(Ok(_stream)) => {
                     info!("Successfully connected to node at: {}", address);
-                    self.connected_nodes.write().unwrap().insert(address);
+                    self.connected_nodes.write().await.insert(address);
                     return Ok(());
                 }
                 Ok(Err(e)) => {
@@ -39,8 +40,8 @@ impl NetworkManager {
         Err("Failed to connect after retries".into())
     }
 
-    pub fn disconnect_node(&self, address: &SocketAddr) {
-        let mut nodes = self.connected_nodes.write().unwrap();
+    pub async fn disconnect_node(&self, address: &SocketAddr) {
+        let mut nodes = self.connected_nodes.write().await;
         if nodes.remove(address) {
             info!("Disconnected from node at: {}", address);
         } else {
@@ -48,8 +49,8 @@ impl NetworkManager {
         }
     }
 
-    pub fn list_connected_nodes(&self) -> Vec<SocketAddr> {
-        let nodes = self.connected_nodes.read().unwrap();
+    pub async fn list_connected_nodes(&self) -> Vec<SocketAddr> {
+        let nodes = self.connected_nodes.read().await;
         nodes.iter().cloned().collect()
     }
 }
@@ -69,23 +70,23 @@ mod tests {
         assert!(result.is_err()); // Expected to fail as there is no server at this address
     }
 
-    #[test]
-    fn test_disconnect_node() {
+    #[tokio::test]
+    async fn test_disconnect_node() {
         let network_manager = NetworkManager::new();
         let test_address: SocketAddr = "127.0.0.1:8080".parse().unwrap();
-        network_manager.connected_nodes.write().unwrap().insert(test_address);
+        network_manager.connected_nodes.write().await.insert(test_address);
 
-        network_manager.disconnect_node(&test_address);
-        assert!(!network_manager.connected_nodes.read().unwrap().contains(&test_address));
+        network_manager.disconnect_node(&test_address).await;
+        assert!(!network_manager.connected_nodes.read().await.contains(&test_address));
     }
 
-    #[test]
-    fn test_list_connected_nodes() {
+    #[tokio::test]
+    async fn test_list_connected_nodes() {
         let network_manager = NetworkManager::new();
         let test_address: SocketAddr = "127.0.0.1:8080".parse().unwrap();
-        network_manager.connected_nodes.write().unwrap().insert(test_address);
+        network_manager.connected_nodes.write().await.insert(test_address);
 
-        let nodes = network_manager.list_connected_nodes();
+        let nodes = network_manager.list_connected_nodes().await;
         assert_eq!(nodes.len(), 1);
         assert_eq!(nodes[0], test_address);
     }


### PR DESCRIPTION
## Summary
- replace `std::sync::RwLock` with `tokio::sync::RwLock` in network, election, and consensus modules
- convert read/write accessors to async variants and adjust tests
- ensure compilation with async locks

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_689fbc46b16083289ba3f523be67fab8