### PR TITLE
refactor: clean up import statements

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -1,10 +1,11 @@
 // an_node.rs: Contains the logic for An nodes, including task distribution to Ki nodes and local database handling.
 
-use lapin::{options::*, types::FieldTable, BasicProperties, Connection, ConnectionProperties};
-use serde::{Deserialize, Serialize};
 use std::error::Error;
-use tracing::{error, info};
+
 use futures_util::stream::StreamExt;
+use lapin::{options::*, types::FieldTable, Connection, ConnectionProperties};
+use serde::{Deserialize, Serialize};
+use tracing::{error, info};
 
 #[derive(Serialize, Deserialize, Debug)]
 struct TaskMessage {

--- a/src/node_registry.rs
+++ b/src/node_registry.rs
@@ -2,10 +2,12 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-use uuid::Uuid;
+
 use chrono::Utc;
-use tracing::{info, error};
+use tokio::sync::RwLock;
+use tracing::{error, info};
+use uuid::Uuid;
+
 use crate::common::NodeInfo;
 
 


### PR DESCRIPTION
## Summary
- deduplicate and reorder imports in an_node
- tidy import groups in node_registry

## Testing
- `cargo test` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_689fccf0c61083288616b82d1e6e3fc2