### PR TITLE
Suppress unused code and imports

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,8 @@
 // api.rs: Implements REST API endpoints for interacting with the task recovery system.
+#![allow(dead_code)]
 
-use crate::task_recovery::TaskRecoveryManager;
 use crate::common::Task;
-use serde::Deserialize;
+use crate::task_recovery::TaskRecoveryManager;
 use std::sync::Arc;
 use uuid::Uuid;
 use warp::http::StatusCode;

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,3 +1,0 @@
-// authentication.rs: Re-exports token utilities from the security module.
-
-pub use crate::security::{generate_token, renew_token, verify_token};

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,15 +1,16 @@
 // backup.rs: Implements a backup mechanism for task persistence to enhance robustness and redundancy.
+#![allow(dead_code)]
 
 use crate::common::Task;
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
-use std::sync::{Arc, RwLock};
 use std::collections::HashMap;
-use tracing::{info, error};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, RwLock};
+use tracing::info;
 use uuid::Uuid;
 use chrono::Utc;
 use std::error::Error;
-use std::path::Path;
 
 #[derive(Clone)]
 pub struct BackupManager {

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 use tokio_postgres::types::ToSql;

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -1,4 +1,5 @@
 // dht.rs: Implements a distributed hash table (DHT) for node discovery and coordination.
+#![allow(dead_code)]
 
 use crate::common::NodeInfo;
 use crate::database::Database;
@@ -9,13 +10,13 @@ use tracing::{error, info};
 use uuid::Uuid;
 
 #[derive(Clone)]
-pub struct DHT {
+pub struct Dht {
     nodes: Arc<RwLock<HashMap<Uuid, NodeInfo>>>,
 }
 
-impl DHT {
+impl Dht {
     pub fn new() -> Self {
-        DHT {
+        Dht {
             nodes: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -50,7 +51,7 @@ impl DHT {
 }
 
 // Store DHT in the database
-pub async fn store_dht_in_db(dht: &DHT, db: &Database) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn store_dht_in_db(dht: &Dht, db: &Database) -> Result<(), Box<dyn std::error::Error>> {
     let nodes = dht.list_nodes().await;
     for node in nodes {
         let node_id_str = node.id.to_string();
@@ -68,8 +69,8 @@ pub async fn store_dht_in_db(dht: &DHT, db: &Database) -> Result<(), Box<dyn std
     Ok(())
 }
 
-pub async fn load_dht_from_db(db: &Database) -> Result<DHT, Box<dyn std::error::Error>> {
-    let dht = DHT::new();
+pub async fn load_dht_from_db(db: &Database) -> Result<Dht, Box<dyn std::error::Error>> {
+    let dht = Dht::new();
     let rows = db
         .query("SELECT node_id, node_info FROM dht", &[])
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ mod an_node;
 mod ki_node;
 mod principal;
 mod security; // Added security module
-mod authentication; // Re-exported token utilities
 mod node_registry; // Added node registry module
 mod backup; // Added backup module
 mod api; // Added API module

--- a/src/node_registry.rs
+++ b/src/node_registry.rs
@@ -1,4 +1,5 @@
 // node_registry.rs: Implements a node registry for keeping track of active nodes in the distributed neural network system.
+#![allow(dead_code)]
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -104,6 +104,7 @@ async fn process_update_request(update: UpdateRequest) -> Result<(), Box<dyn Err
     Ok(())
 }
 
+#[allow(dead_code)]
 pub async fn assign_role(
     node_id: &str,
     role: &str,

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,4 +1,5 @@
 // security.rs: Implements security mechanisms including encryption, decryption, and authentication for nodes.
+#![allow(dead_code)]
 
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Key, Nonce};

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -1,4 +1,5 @@
 // task_recovery.rs: Implements task persistence and recovery for robustness.
+#![allow(dead_code)]
 
 use crate::common::Task;
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary
- remove unused authentication re-export
- suppress unused code warnings across modules
- rename `DHT` to `Dht` to satisfy clippy acronym lint

## Testing
- `cargo clippy --all-targets --all-features`

------
https://chatgpt.com/codex/tasks/task_e_689fd1119e6c8328834485ed5105a215