### PR TITLE
Refactor node messaging to use centralized helpers

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -2,8 +2,9 @@
 
 use std::error::Error;
 
+use crate::messaging::{consume_messages, declare_queue, establish_connection};
 use futures_util::stream::StreamExt;
-use lapin::{options::*, types::FieldTable, Connection, ConnectionProperties};
+use lapin::options::{BasicAckOptions, BasicNackOptions};
 use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 
@@ -19,40 +20,14 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         error!("Failed to read AMQP_ADDR environment variable: {:?}", e);
         e
     })?;
-    let connection = Connection::connect(&amqp_addr, ConnectionProperties::default()).await.map_err(|e| {
-        error!("Failed to connect to RabbitMQ: {:?}", e);
-        e
-    })?;
-    let channel = connection.create_channel().await.map_err(|e| {
-        error!("Failed to create channel: {:?}", e);
-        e
-    })?;
+    let channel = establish_connection(&amqp_addr).await?;
 
     // Declare the queue for receiving tasks from the principal
     let queue_name = "an_task_queue";
-    channel
-        .queue_declare(
-            queue_name,
-            QueueDeclareOptions::default(),
-            FieldTable::default(),
-        )
-        .await.map_err(|e| {
-            error!("Failed to declare queue: {:?}", e);
-            e
-        })?;
+    declare_queue(&channel, queue_name).await?;
 
     // Start consuming tasks from the queue
-    let mut consumer = channel
-        .basic_consume(
-            queue_name,
-            "an_consumer",
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
-        )
-        .await.map_err(|e| {
-            error!("Failed to start consuming: {:?}", e);
-            e
-        })?;
+    let mut consumer = consume_messages(&channel, queue_name, "an_consumer").await?;
 
     info!("An node is running and waiting for tasks...");
 

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -1,7 +1,8 @@
 // ki_node.rs: Manages the Ki node behavior, including fetching inputs, running computations, and sending outputs.
 
+use crate::messaging::{consume_messages, declare_queue, establish_connection, publish_message};
 use futures_util::stream::StreamExt;
-use lapin::{options::*, types::FieldTable, BasicProperties, Connection, ConnectionProperties};
+use lapin::options::BasicAckOptions;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use tracing::{error, info};
@@ -24,44 +25,14 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         error!("Failed to read AMQP_ADDR environment variable: {:?}", e);
         e
     })?;
-    let connection = Connection::connect(&amqp_addr, ConnectionProperties::default())
-        .await
-        .map_err(|e| {
-            error!("Failed to connect to RabbitMQ: {:?}", e);
-            e
-        })?;
-    let channel = connection.create_channel().await.map_err(|e| {
-        error!("Failed to create channel: {:?}", e);
-        e
-    })?;
+    let channel = establish_connection(&amqp_addr).await?;
 
     // Declare the queue for receiving tasks from the An node
     let queue_name = "ki_task_queue";
-    channel
-        .queue_declare(
-            queue_name,
-            QueueDeclareOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to declare queue: {:?}", e);
-            e
-        })?;
+    declare_queue(&channel, queue_name).await?;
 
     // Start consuming tasks from the queue
-    let mut consumer = channel
-        .basic_consume(
-            queue_name,
-            "ki_consumer",
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to start consuming: {:?}", e);
-            e
-        })?;
+    let mut consumer = consume_messages(&channel, queue_name, "ki_consumer").await?;
 
     info!("Ki node is running and waiting for tasks...");
 
@@ -122,20 +93,7 @@ async fn send_result(
         e
     })?;
 
-    // Publish the result to the An node
-    channel
-        .basic_publish(
-            "",
-            result_queue,
-            BasicPublishOptions::default(),
-            &payload,
-            BasicProperties::default(),
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to publish result: {:?}", e);
-            e
-        })?;
+    publish_message(channel, result_queue, &payload).await?;
 
     info!("Sent result for task ID: {}", result.task_id);
     Ok(())

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -1,6 +1,7 @@
 // principal.rs: Implements the specific responsibilities of the Principal, including role management and global coordination.
+use crate::messaging::{consume_messages, declare_queue, establish_connection, publish_message};
 use futures_util::stream::StreamExt;
-use lapin::{options::*, types::FieldTable, BasicProperties, Connection, ConnectionProperties};
+use lapin::options::BasicAckOptions;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use tracing::{error, info};
@@ -23,44 +24,14 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         error!("Failed to read AMQP_ADDR environment variable: {:?}", e);
         e
     })?;
-    let connection = Connection::connect(&amqp_addr, ConnectionProperties::default())
-        .await
-        .map_err(|e| {
-            error!("Failed to connect to RabbitMQ: {:?}", e);
-            e
-        })?;
-    let channel = connection.create_channel().await.map_err(|e| {
-        error!("Failed to create channel: {:?}", e);
-        e
-    })?;
+    let channel = establish_connection(&amqp_addr).await?;
 
     // Declare the queue for receiving update requests from An nodes
     let queue_name = "principal_update_queue";
-    channel
-        .queue_declare(
-            queue_name,
-            QueueDeclareOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to declare queue: {:?}", e);
-            e
-        })?;
+    declare_queue(&channel, queue_name).await?;
 
     // Start consuming update requests from the queue
-    let mut consumer = channel
-        .basic_consume(
-            queue_name,
-            "principal_consumer",
-            BasicConsumeOptions::default(),
-            FieldTable::default(),
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to start consuming: {:?}", e);
-            e
-        })?;
+    let mut consumer = consume_messages(&channel, queue_name, "principal_consumer").await?;
 
     info!("Principal node is running and waiting for update requests...");
 
@@ -123,19 +94,7 @@ pub async fn assign_role(
 
     // Publish the role assignment to the role management queue
     let role_queue = "role_assignment_queue";
-    channel
-        .basic_publish(
-            "",
-            role_queue,
-            BasicPublishOptions::default(),
-            &payload,
-            BasicProperties::default(),
-        )
-        .await
-        .map_err(|e| {
-            error!("Failed to publish role assignment: {:?}", e);
-            e
-        })?;
+    publish_message(channel, role_queue, &payload).await?;
 
     info!("Assigned role '{}' to node '{}'", role, node_id);
     Ok(())


### PR DESCRIPTION
## Summary
- Replace direct RabbitMQ operations in An, Ki, and Principal nodes with messaging helper functions
- Simplify node imports by relying on shared messaging utilities for connection, queue setup, publishing, and consumption

## Testing
- `cargo test` *(fails: messaging::tests::test_messaging_workflow; RabbitMQ broker unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c16f6c848328a8aea12ca587663b