### PR TITLE
chore: add pre-commit linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+      - id: clippy

--- a/README.md
+++ b/README.md
@@ -170,3 +170,20 @@ DELETE /tasks/{task_id}: Delete a specific task by providing the task ID.
 curl -X DELETE http://localhost:3030/tasks/{task_id}
 
 These endpoints allow external interaction with the distributed network, such as adding new tasks or querying the current tasks.
+
+## Development
+
+### Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to automatically run `cargo fmt` and `cargo clippy` on commits. Install pre-commit and set up the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run all checks manually with:
+
+```bash
+pre-commit run --all-files
+```


### PR DESCRIPTION
## Summary
- add pre-commit configuration for cargo fmt and clippy
- document pre-commit setup in README

## Testing
- `pre-commit run --all-files` *(fails: unclosed delimiters in src/an_node.rs)*
- `cargo test` *(fails: could not compile distributed_neural_network)*

------
https://chatgpt.com/codex/tasks/task_e_68a796e8ece48328a96a0b88bfcfba2c