### PR TITLE
Clean up module declarations in main entry point

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,27 +4,19 @@ use std::env;
 use tracing::error;
 
 mod an_node;
-mod api; // Added API module
-mod backup; // Added backup module
-mod common; // Shared types
-mod database; // Database abstraction
-mod ki_node;
-mod principal;
+mod api;
+mod backup;
+mod common;
 mod config;
-mod security; // Added security module
-mod node_registry; // Added node registry module
-mod backup; // Added backup module
-mod api; // Added API module
-mod task_recovery; // Added task recovery module
-mod dht; // Distributed hash table utilities
+mod dht;
 mod ki_node;
-mod load_balancer; // Load balancing logic
+mod load_balancer;
 mod messaging;
-mod node_registry; // Added node registry module
+mod node_registry;
 mod principal;
-mod security; // Added security module
-mod signals; // Signal handling utilities
-mod task_recovery; // Added task recovery module // Messaging module for RabbitMQ interactions
+mod security;
+mod signals;
+mod task_recovery;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
## Summary
- remove duplicate `mod` declarations in `main.rs`
- drop nonexistent `database` module reference
- organize module list for clarity

## Testing
- `cargo test` *(fails: this file contains an unclosed delimiter in src/an_node.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e59739308328a34ba8edb649c2a2