### PR TITLE
Remove unused tracing imports

### DIFF
--- a/src/logging_metrics.rs
+++ b/src/logging_metrics.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use prometheus::{register_counter, register_histogram, Counter, Encoder, Histogram, TextEncoder};
 use std::convert::Infallible;
 use std::time::{Duration, Instant};
-use tracing::{debug, error, info, warn, Level};
+use tracing::{debug, error, info};
 use tracing_subscriber::{fmt, EnvFilter};
 use warp::Filter;
 


### PR DESCRIPTION
## Summary
- clean up unused `tracing` imports in `logging_metrics`

## Testing
- `cargo clippy` *(fails: this file contains an unclosed delimiter in src/an_node.rs)*
- `cargo clippy --lib`

------
https://chatgpt.com/codex/tasks/task_e_68b1e59aafd08328a9cbbb58f70266cd