### PR TITLE
Indent list_nodes method in Dht

### DIFF
--- a/src/dht.rs
+++ b/src/dht.rs
@@ -42,10 +42,10 @@ impl Dht {
         nodes.get(node_id).cloned()
     }
 
-pub async fn list_nodes(&self) -> Vec<NodeInfo> {
-    let nodes = self.nodes.read().await;
-    nodes.values().cloned().collect()
-}
+    pub async fn list_nodes(&self) -> Vec<NodeInfo> {
+        let nodes = self.nodes.read().await;
+        nodes.values().cloned().collect()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- indent `list_nodes` method in `Dht` implementation for consistent formatting

## Testing
- `cargo fmt -- src/dht.rs` *(fails: unclosed delimiter in src/an_node.rs)*
- `rustfmt --edition 2021 src/dht.rs`
- `cargo test` *(fails: unclosed delimiter in src/an_node.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e59bb4708328b5a135d1e9fe4425