### PR TITLE
Add observability with OpenTelemetry and Grafana

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +696,9 @@ dependencies = [
  "lapin",
  "lazy_static",
  "nix",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prometheus",
  "rand 0.8.5",
  "regex",
@@ -699,6 +708,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
  "warp",
@@ -709,6 +719,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -841,6 +857,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,9 +931,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -973,6 +1002,25 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1071,6 +1119,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,9 +1163,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1104,6 +1175,65 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.7.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1289,6 +1419,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde 1.0.219",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1559,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "md-5"
@@ -1601,6 +1765,82 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+dependencies = [
+ "http 1.3.1",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.12",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "overload"
@@ -1916,6 +2156,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,8 +2295,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2044,14 +2316,54 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde 1.0.219",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -2509,6 +2821,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2694,6 +3015,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,6 +3058,75 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde 1.0.219",
 ]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -2778,15 +3179,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2950,7 +3373,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.32",
  "log",
  "mime",
  "mime_guess",
@@ -3016,6 +3439,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,6 +3488,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,11 @@ prometheus = "0.13"
 
 # Logging and tracing
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+opentelemetry = "0.30"
+opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.30", features = ["grpc-tonic"] }
+tracing-opentelemetry = "0.31"
 
 # Environment variable configuration
 config = "0.11"

--- a/README.md
+++ b/README.md
@@ -187,3 +187,30 @@ Run all checks manually with:
 ```bash
 pre-commit run --all-files
 ```
+
+## Monitoring
+
+### OpenTelemetry Collector
+
+An OpenTelemetry Collector can aggregate metrics and traces from regional nodes. A sample configuration is available at
+`config/otel-collector-config.yaml`. Run the collector with Docker:
+
+```bash
+docker run --rm -p 4317:4317 -p 9464:9464 \
+  -v $(pwd)/config/otel-collector-config.yaml:/etc/otel-collector-config.yaml \
+  otel/opentelemetry-collector:latest \
+  --config /etc/otel-collector-config.yaml
+```
+
+Nodes export traces to the collector via OTLP on port `4317` and expose Prometheus metrics on port `9090`. The collector
+scrapes these metrics and re-exports them on `9464` for federation.
+
+### Grafana Dashboard
+
+Import the sample dashboard found at `config/grafana/node_overview.json` into Grafana. It visualizes:
+
+- **Node Status:** current health of each node.
+- **Consensus State:** leader or follower role.
+- **Task Throughput:** rate of tasks processed per minute.
+
+Configure Grafana to use the collector's Prometheus exporter (`http://localhost:9464`) as a data source.

--- a/config/grafana/node_overview.json
+++ b/config/grafana/node_overview.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 30,
+  "title": "Node Overview",
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Node Status",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "node_status"}],
+      "gridPos": {"x": 0, "y": 0, "w": 8, "h": 4}
+    },
+    {
+      "type": "graph",
+      "title": "Consensus State",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "consensus_state"}],
+      "gridPos": {"x": 8, "y": 0, "w": 8, "h": 6}
+    },
+    {
+      "type": "graph",
+      "title": "Task Throughput",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "rate(tasks_processed_total[1m])"}],
+      "gridPos": {"x": 0, "y": 4, "w": 16, "h": 8}
+    }
+  ]
+}

--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'an-ki'
+          static_configs:
+            - targets: ['principal:9090','an:9090','ki:9090']
+
+exporters:
+  prometheus:
+    endpoint: ":9464"
+  logging:
+    loglevel: debug
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      exporters: [prometheus, logging]
+    traces:
+      receivers: [otlp]
+      exporters: [logging]

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,12 +1,13 @@
 // consensus.rs: Implements a consensus algorithm to ensure consistency across An nodes.
 
+use crate::logging_metrics;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::error::Error;
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc, RwLock};
+use tracing::{error, info};
 use uuid::Uuid;
-use tracing::{info, error};
-use std::error::Error;
-use serde::{Serialize, Deserialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConsensusProposal {
@@ -40,7 +41,10 @@ impl ConsensusState {
         let mut votes = self.votes.write().await;
         if let Some(vote_count) = votes.get_mut(&proposal_id) {
             *vote_count += 1;
-            info!("Cast vote for proposal: {}. Current votes: {}", proposal_id, *vote_count);
+            info!(
+                "Cast vote for proposal: {}. Current votes: {}",
+                proposal_id, *vote_count
+            );
         } else {
             error!("Proposal not found: {}", proposal_id);
         }
@@ -71,6 +75,7 @@ pub async fn run_consensus_protocol(
                 consensus_state.cast_vote(proposal_id).await;
                 if consensus_state.has_consensus(proposal_id, consensus_threshold).await {
                     info!("Consensus reached for proposal: {}", proposal_id);
+                    logging_metrics::set_consensus_state(1.0);
                     // Handle the proposal that reached consensus (e.g., apply an update to the database)
                 }
             }

--- a/src/logging_metrics.rs
+++ b/src/logging_metrics.rs
@@ -1,11 +1,19 @@
 // logging_metrics.rs: Implements logging and metrics collection for monitoring node health and performance.
 
 use lazy_static::lazy_static;
-use prometheus::{register_counter, register_histogram, Counter, Encoder, Histogram, TextEncoder};
+use opentelemetry::{global, trace::TracerProvider as _};
+use opentelemetry_otlp::{SpanExporter, WithExportConfig};
+use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
+use prometheus::{
+    register_counter, register_gauge, register_histogram, Counter, Encoder, Gauge, Histogram,
+    TextEncoder,
+};
 use std::convert::Infallible;
-use std::time::{Duration, Instant};
-use tracing::{debug, error, info};
-use tracing_subscriber::{fmt, EnvFilter};
+use std::time::Instant;
+use tracing::{debug, info};
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter, Registry};
 use warp::Filter;
 
 // Metrics definitions
@@ -20,14 +28,48 @@ lazy_static! {
         "Histogram of task processing times"
     )
     .unwrap();
+    static ref NODE_STATUS: Gauge =
+        register_gauge!("node_status", "Current status of the node (1=up, 0=down)").unwrap();
+    static ref CONSENSUS_STATE: Gauge = register_gauge!(
+        "consensus_state",
+        "Consensus state of the node (1=leader, 0=follower)"
+    )
+    .unwrap();
 }
 
 pub fn init_logging() {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_level(true)
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint("http://localhost:4317")
+        .build()
+        .expect("failed to create OTLP exporter");
+
+    let processor = BatchSpanProcessor::builder(exporter).build();
+    let provider = SdkTracerProvider::builder()
+        .with_span_processor(processor)
+        .build();
+
+    let tracer = provider.tracer("an-ki");
+    let otel_layer = OpenTelemetryLayer::new(tracer);
+
+    global::set_tracer_provider(provider);
+
+    Registry::default()
+        .with(fmt::layer().with_target(false))
+        .with(EnvFilter::from_default_env())
+        .with(otel_layer)
         .init();
+
+    set_node_status(1.0);
     info!("Logging initialized.");
+}
+
+pub fn set_node_status(status: f64) {
+    NODE_STATUS.set(status);
+}
+
+pub fn set_consensus_state(state: f64) {
+    CONSENSUS_STATE.set(state);
 }
 
 pub fn log_task_processing(start_time: Instant) {
@@ -67,6 +109,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_metrics_endpoint() {
+        use warp::Reply;
         let response = metrics_endpoint().await.unwrap();
         assert!(response.into_response().status().is_success());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod config;
 mod dht;
 mod ki_node;
 mod load_balancer;
+mod logging_metrics;
 mod messaging;
 mod node_registry;
 mod principal;
@@ -20,8 +21,9 @@ mod task_recovery;
 
 #[tokio::main]
 async fn main() {
-    // Initialize tracing subscriber for logging
-    tracing_subscriber::fmt::init();
+    // Initialize tracing and metrics
+    logging_metrics::init_logging();
+    let _ = tokio::spawn(logging_metrics::run_metrics_server());
 
     // Determine the node type based on an environment variable or command-line argument
     let args: Vec<String> = env::args().collect();
@@ -34,18 +36,21 @@ async fn main() {
 
     match node_type.as_str() {
         "principal" => {
+            logging_metrics::set_consensus_state(1.0);
             if let Err(e) = principal::run().await {
                 error!("Failed to run principal node: {:?}", e);
                 std::process::exit(1);
             }
         }
         "an" => {
+            logging_metrics::set_consensus_state(0.0);
             if let Err(e) = an_node::run().await {
                 error!("Failed to run an node: {:?}", e);
                 std::process::exit(1);
             }
         }
         "ki" => {
+            logging_metrics::set_consensus_state(0.0);
             if let Err(e) = ki_node::run().await {
                 error!("Failed to run ki node: {:?}", e);
                 std::process::exit(1);

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,17 +1,23 @@
 // network.rs: Abstracts network operations such as connecting nodes and handling retries.
 
-use tokio::net::TcpStream;
-use tokio::time::{timeout, Duration};
-use tracing::{info, error};
+use std::collections::HashSet;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use tokio::net::TcpStream;
 use tokio::sync::RwLock;
-use std::collections::HashSet;
+use tokio::time::{timeout, Duration};
+use tracing::{error, info};
 
 #[derive(Clone, Debug)]
 pub struct NetworkManager {
     pub connected_nodes: Arc<RwLock<HashSet<SocketAddr>>>,
+}
+
+impl Default for NetworkManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl NetworkManager {
@@ -21,7 +27,12 @@ impl NetworkManager {
         }
     }
 
-    pub async fn connect_to_node(&self, address: SocketAddr, retry_count: u32, timeout_duration: Duration) -> Result<(), Box<dyn Error>> {
+    pub async fn connect_to_node(
+        &self,
+        address: SocketAddr,
+        retry_count: u32,
+        timeout_duration: Duration,
+    ) -> Result<(), Box<dyn Error>> {
         for attempt in 0..retry_count {
             match timeout(timeout_duration, TcpStream::connect(address)).await {
                 Ok(Ok(_stream)) => {
@@ -30,10 +41,21 @@ impl NetworkManager {
                     return Ok(());
                 }
                 Ok(Err(e)) => {
-                    error!("Failed to connect to node at {}: {}. Attempt {}/{}", address, e, attempt + 1, retry_count);
+                    error!(
+                        "Failed to connect to node at {}: {}. Attempt {}/{}",
+                        address,
+                        e,
+                        attempt + 1,
+                        retry_count
+                    );
                 }
                 Err(_) => {
-                    error!("Connection to node at {} timed out. Attempt {}/{}", address, attempt + 1, retry_count);
+                    error!(
+                        "Connection to node at {} timed out. Attempt {}/{}",
+                        address,
+                        attempt + 1,
+                        retry_count
+                    );
                 }
             }
         }
@@ -94,13 +116,11 @@ mod tests {
             .insert(test_address);
 
         network_manager.disconnect_node(&test_address).await;
-        assert!(
-            !network_manager
-                .connected_nodes
-                .read()
-                .await
-                .contains(&test_address)
-        );
+        assert!(!network_manager
+            .connected_nodes
+            .read()
+            .await
+            .contains(&test_address));
     }
 
     #[tokio::test]

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -1,15 +1,15 @@
 // principal.rs: Implements the specific responsibilities of the Principal, including role management and global coordination.
 
+use crate::messaging::{consume_messages, declare_queue, publish_message};
 use crate::signals;
-use crate::messaging::{consume_messages, declare_queue, establish_connection, publish_message};
 
+use crate::config::load_settings;
 use futures_util::stream::StreamExt;
-use lapin::options::BasicAckOptions;
+use lapin::{options::BasicAckOptions, Connection, ConnectionProperties};
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use tokio::sync::oneshot;
 use tracing::{error, info};
-use crate::config::load_settings;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RoleAssignment {
@@ -38,13 +38,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     });
 
     // Establish connection to RabbitMQ
-    let amqp_addr = std::env::var("AMQP_ADDR").map_err(|e| {
-        error!("Failed to read AMQP_ADDR environment variable: {:?}", e);
-
-    // Establish connection to RabbitMQ using configuration settings
+    // Load configuration and establish connection to RabbitMQ
     let settings = load_settings().map_err(|e| {
         error!("Failed to load settings: {:?}", e);
-
         e
     })?;
 


### PR DESCRIPTION
## Summary
- integrate OpenTelemetry tracing and Prometheus metrics
- add sample OpenTelemetry Collector and Grafana dashboard configs
- document monitoring setup in README

## Testing
- `pre-commit run --all-files` *(fails: numerous clippy warnings in existing modules)*
- `cargo test` *(hangs: several tests running over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68b46f0231c08328b44028641e938c3d