### PR TITLE
Add Docker deployment resources and configurable settings

### DIFF
--- a/Dockerfile.an
+++ b/Dockerfile.an
@@ -1,0 +1,15 @@
+# Dockerfile for the An node
+# syntax=docker/dockerfile:1
+
+FROM rust:1.74 as builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY config ./config
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /app/target/release/distributed_neural_network /usr/local/bin/an-ki
+COPY config/default.toml /config/default.toml
+CMD ["an-ki", "an"]

--- a/Dockerfile.ki
+++ b/Dockerfile.ki
@@ -1,0 +1,15 @@
+# Dockerfile for the Ki node
+# syntax=docker/dockerfile:1
+
+FROM rust:1.74 as builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY config ./config
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /app/target/release/distributed_neural_network /usr/local/bin/an-ki
+COPY config/default.toml /config/default.toml
+CMD ["an-ki", "ki"]

--- a/Dockerfile.principal
+++ b/Dockerfile.principal
@@ -1,0 +1,15 @@
+# Dockerfile for the principal node
+# syntax=docker/dockerfile:1
+
+FROM rust:1.74 as builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY config ./config
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /app/target/release/distributed_neural_network /usr/local/bin/an-ki
+COPY config/default.toml /config/default.toml
+CMD ["an-ki", "principal"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A distributed neural network project that supports task scheduling, load balanci
 - [Usage](#usage)
   - [Running the Nodes](#running-the-nodes)
   - [API Endpoints](#api-endpoints)
+- [Deployment](#deployment)
 - [Modules Overview](#modules-overview)
 - [Development](#development)
   - [Testing](#testing)
@@ -170,6 +171,42 @@ DELETE /tasks/{task_id}: Delete a specific task by providing the task ID.
 curl -X DELETE http://localhost:3030/tasks/{task_id}
 
 These endpoints allow external interaction with the distributed network, such as adding new tasks or querying the current tasks.
+
+## Deployment
+
+### Docker Images
+
+Separate Dockerfiles are provided for each node type. Build the images using:
+
+```bash
+docker build -f Dockerfile.principal -t an-ki:principal .
+docker build -f Dockerfile.an -t an-ki:an .
+docker build -f Dockerfile.ki -t an-ki:ki .
+```
+
+Each image runs the appropriate node (`principal`, `an`, or `ki`) when started.
+
+### Helm Chart
+
+A Helm chart in `helm/an-ki` simplifies Kubernetes deployment. Replica counts and core
+settings are configurable through `values.yaml`, with environment-specific overrides
+available in files like `values-dev.yaml` and `values-prod.yaml`.
+
+Deploy to a cluster with:
+
+```bash
+helm install an-ki ./helm/an-ki -f helm/an-ki/values.yaml -f helm/an-ki/values-dev.yaml
+```
+
+Override the `values-dev.yaml` file with `values-prod.yaml` or your own file for
+production environments.
+
+### Service Discovery
+
+Within Kubernetes, each node is exposed via a `Service`, enabling discovery through
+Kubernetes DNS (e.g., `principal.default.svc.cluster.local`). Outside Kubernetes,
+nodes rely on the built-in DHT for dynamic discovery or can be configured with
+explicit addresses using the configuration system.
 
 ## Development
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,6 +1,8 @@
-# Example configuration for the distributed neural network system
-# Copy this file to `config/default.toml` and adjust values as needed
+# Default configuration for the distributed neural network system
+# Values can be overridden with environment variables or `*_FILE` entries provided
+# by ConfigMaps. For example, set `AMQP_ADDR` or `AMQP_ADDR_FILE` to override
+# `amqp_addr`.
 
 amqp_addr = "amqp://127.0.0.1:5672/%2f"
-jwt_secret_key = "<JWT_SECRET_KEY>"
+jwt_secret_key = "change-me"
 database_url = "postgresql://root@localhost:26257/defaultdb?sslmode=disable"

--- a/helm/an-ki/Chart.yaml
+++ b/helm/an-ki/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: an-ki
+version: 0.1.0
+description: Helm chart for deploying principal, An, and Ki nodes

--- a/helm/an-ki/templates/an-deployment.yaml
+++ b/helm/an-ki/templates/an-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: an
+spec:
+  replicas: {{ .Values.an.replicas }}
+  selector:
+    matchLabels:
+      app: an
+  template:
+    metadata:
+      labels:
+        app: an
+    spec:
+      containers:
+        - name: an
+          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag }}
+          command: ["an-ki", "an"]
+          env:
+            - name: AMQP_ADDR
+              value: {{ .Values.global.amqpAddr | quote }}
+            - name: JWT_SECRET_KEY
+              value: {{ .Values.global.jwtSecretKey | quote }}
+            - name: DATABASE_URL
+              value: {{ .Values.global.databaseUrl | quote }}
+          ports:
+            - containerPort: 3030

--- a/helm/an-ki/templates/an-service.yaml
+++ b/helm/an-ki/templates/an-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: an
+spec:
+  selector:
+    app: an
+  ports:
+    - port: 3030
+      targetPort: 3030

--- a/helm/an-ki/templates/ki-deployment.yaml
+++ b/helm/an-ki/templates/ki-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ki
+spec:
+  replicas: {{ .Values.ki.replicas }}
+  selector:
+    matchLabels:
+      app: ki
+  template:
+    metadata:
+      labels:
+        app: ki
+    spec:
+      containers:
+        - name: ki
+          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag }}
+          command: ["an-ki", "ki"]
+          env:
+            - name: AMQP_ADDR
+              value: {{ .Values.global.amqpAddr | quote }}
+            - name: JWT_SECRET_KEY
+              value: {{ .Values.global.jwtSecretKey | quote }}
+            - name: DATABASE_URL
+              value: {{ .Values.global.databaseUrl | quote }}
+          ports:
+            - containerPort: 3030

--- a/helm/an-ki/templates/ki-service.yaml
+++ b/helm/an-ki/templates/ki-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ki
+spec:
+  selector:
+    app: ki
+  ports:
+    - port: 3030
+      targetPort: 3030

--- a/helm/an-ki/templates/principal-deployment.yaml
+++ b/helm/an-ki/templates/principal-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: principal
+spec:
+  replicas: {{ .Values.principal.replicas }}
+  selector:
+    matchLabels:
+      app: principal
+  template:
+    metadata:
+      labels:
+        app: principal
+    spec:
+      containers:
+        - name: principal
+          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag }}
+          command: ["an-ki", "principal"]
+          env:
+            - name: AMQP_ADDR
+              value: {{ .Values.global.amqpAddr | quote }}
+            - name: JWT_SECRET_KEY
+              value: {{ .Values.global.jwtSecretKey | quote }}
+            - name: DATABASE_URL
+              value: {{ .Values.global.databaseUrl | quote }}
+          ports:
+            - containerPort: 3030

--- a/helm/an-ki/templates/principal-service.yaml
+++ b/helm/an-ki/templates/principal-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: principal
+spec:
+  selector:
+    app: principal
+  ports:
+    - port: 3030
+      targetPort: 3030

--- a/helm/an-ki/values-dev.yaml
+++ b/helm/an-ki/values-dev.yaml
@@ -1,0 +1,6 @@
+principal:
+  replicas: 1
+an:
+  replicas: 1
+ki:
+  replicas: 1

--- a/helm/an-ki/values-prod.yaml
+++ b/helm/an-ki/values-prod.yaml
@@ -1,0 +1,6 @@
+principal:
+  replicas: 2
+an:
+  replicas: 3
+ki:
+  replicas: 5

--- a/helm/an-ki/values.yaml
+++ b/helm/an-ki/values.yaml
@@ -1,0 +1,15 @@
+global:
+  imageRepository: an-ki
+  imageTag: latest
+  amqpAddr: amqp://rabbitmq:5672/%2f
+  jwtSecretKey: change-me
+  databaseUrl: postgresql://user:pass@db:5432/app
+
+principal:
+  replicas: 1
+
+an:
+  replicas: 1
+
+ki:
+  replicas: 1

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@
 use config::{Config, ConfigError, Environment, File, FileFormat};
 use serde::Deserialize;
 use std::env;
+use std::fs;
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]
@@ -31,8 +32,24 @@ impl Settings {
         // Add in settings from environment variables (with a prefix of "APP")
         s.merge(Environment::with_prefix("APP"))?;
 
+        // Allow overrides from unprefixed env vars or file-based entries for ConfigMaps
+        override_from_env_or_file(&mut s, "amqp_addr", "AMQP_ADDR")?;
+        override_from_env_or_file(&mut s, "jwt_secret_key", "JWT_SECRET_KEY")?;
+        override_from_env_or_file(&mut s, "database_url", "DATABASE_URL")?;
+
         s.try_into()
     }
+}
+
+fn override_from_env_or_file(s: &mut Config, key: &str, env_var: &str) -> Result<(), ConfigError> {
+    if let Ok(val) = env::var(env_var) {
+        s.set(key, val)?;
+    } else if let Ok(path) = env::var(format!("{}_FILE", env_var)) {
+        if let Ok(contents) = fs::read_to_string(path) {
+            s.set(key, contents.trim())?;
+        }
+    }
+    Ok(())
 }
 
 /// Convenience function to load [`Settings`] using the default configuration

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,13 +1,13 @@
 // network.rs: Abstracts network operations such as connecting nodes and handling retries.
 
-use tokio::net::TcpStream;
-use tokio::time::{timeout, Duration};
-use tracing::{info, error};
+use std::collections::HashSet;
 use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use tokio::net::TcpStream;
 use tokio::sync::RwLock;
-use std::collections::HashSet;
+use tokio::time::{timeout, Duration};
+use tracing::{error, info};
 
 #[derive(Clone, Debug)]
 pub struct NetworkManager {
@@ -21,7 +21,12 @@ impl NetworkManager {
         }
     }
 
-    pub async fn connect_to_node(&self, address: SocketAddr, retry_count: u32, timeout_duration: Duration) -> Result<(), Box<dyn Error>> {
+    pub async fn connect_to_node(
+        &self,
+        address: SocketAddr,
+        retry_count: u32,
+        timeout_duration: Duration,
+    ) -> Result<(), Box<dyn Error>> {
         for attempt in 0..retry_count {
             match timeout(timeout_duration, TcpStream::connect(address)).await {
                 Ok(Ok(_stream)) => {
@@ -30,10 +35,21 @@ impl NetworkManager {
                     return Ok(());
                 }
                 Ok(Err(e)) => {
-                    error!("Failed to connect to node at {}: {}. Attempt {}/{}", address, e, attempt + 1, retry_count);
+                    error!(
+                        "Failed to connect to node at {}: {}. Attempt {}/{}",
+                        address,
+                        e,
+                        attempt + 1,
+                        retry_count
+                    );
                 }
                 Err(_) => {
-                    error!("Connection to node at {} timed out. Attempt {}/{}", address, attempt + 1, retry_count);
+                    error!(
+                        "Connection to node at {} timed out. Attempt {}/{}",
+                        address,
+                        attempt + 1,
+                        retry_count
+                    );
                 }
             }
         }
@@ -52,6 +68,12 @@ impl NetworkManager {
     pub async fn list_connected_nodes(&self) -> Vec<SocketAddr> {
         let nodes = self.connected_nodes.read().await;
         nodes.iter().cloned().collect()
+    }
+}
+
+impl Default for NetworkManager {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -94,13 +116,11 @@ mod tests {
             .insert(test_address);
 
         network_manager.disconnect_node(&test_address).await;
-        assert!(
-            !network_manager
-                .connected_nodes
-                .read()
-                .await
-                .contains(&test_address)
-        );
+        assert!(!network_manager
+            .connected_nodes
+            .read()
+            .await
+            .contains(&test_address));
     }
 
     #[tokio::test]

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -1,15 +1,16 @@
 // principal.rs: Implements the specific responsibilities of the Principal, including role management and global coordination.
 
+use crate::messaging::{consume_messages, declare_queue, publish_message};
 use crate::signals;
-use crate::messaging::{consume_messages, declare_queue, establish_connection, publish_message};
+use lapin::{Connection, ConnectionProperties};
 
+use crate::config::load_settings;
 use futures_util::stream::StreamExt;
 use lapin::options::BasicAckOptions;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use tokio::sync::oneshot;
 use tracing::{error, info};
-use crate::config::load_settings;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct RoleAssignment {
@@ -37,14 +38,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         let _ = shutdown_tx.send(());
     });
 
-    // Establish connection to RabbitMQ
-    let amqp_addr = std::env::var("AMQP_ADDR").map_err(|e| {
-        error!("Failed to read AMQP_ADDR environment variable: {:?}", e);
-
     // Establish connection to RabbitMQ using configuration settings
     let settings = load_settings().map_err(|e| {
         error!("Failed to load settings: {:?}", e);
-
         e
     })?;
 


### PR DESCRIPTION
## Summary
- add Dockerfiles for principal, An, and Ki nodes
- introduce Helm chart with replica counts and env overrides
- allow config values to be supplied via env vars or *_FILE for ConfigMaps
- document container deployment and service discovery steps

## Testing
- `pre-commit run --all-files` *(fails: could not compile `distributed_neural_network` due to clippy warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68b46f0125808328a1a374ed70e55d84