### PR TITLE
Integrate basic Raft scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ aes-gcm = { version = "0.10", features = ["std"] }
 rand = "0.8"
 # Testing framework for lazy static initialization
 lazy_static = "1.4"
+openraft = { version = "0.9", features = ["serde", "type-alias"] }
+openraft-memstore = "0.9"
+sled = "0.34"
 
 [dev-dependencies]
 # Testing utilities

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,12 +1,20 @@
-// consensus.rs: Implements a consensus algorithm to ensure consistency across An nodes.
-
-use std::collections::HashMap;
-use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc, RwLock};
-use uuid::Uuid;
-use tracing::{info, error};
+use serde::{Deserialize, Serialize};
 use std::error::Error;
-use serde::{Serialize, Deserialize};
+use std::sync::Arc;
+use tokio::sync::{broadcast, mpsc};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use async_trait::async_trait;
+use openraft::error::{InstallSnapshotError, RPCError, RaftError};
+use openraft::network::{RPCOption, RaftNetwork, RaftNetworkFactory};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest, InstallSnapshotResponse,
+    VoteRequest, VoteResponse,
+};
+use openraft::{BasicNode, Config, Raft};
+use openraft_memstore::{new_mem_store, ClientRequest, TypeConfig};
+use sled::Db;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConsensusProposal {
@@ -15,68 +23,81 @@ pub struct ConsensusProposal {
     pub proposer_id: Uuid,
 }
 
-#[derive(Clone, Debug)]
-pub struct ConsensusState {
-    pub proposals: Arc<RwLock<HashMap<Uuid, ConsensusProposal>>>,
-    pub votes: Arc<RwLock<HashMap<Uuid, usize>>>,
+pub type NodeId = u64;
+
+struct DummyNetwork;
+
+#[async_trait]
+impl RaftNetwork<TypeConfig> for DummyNetwork {
+    async fn append_entries(
+        &mut self,
+        _rpc: AppendEntriesRequest<TypeConfig>,
+        _opt: RPCOption,
+    ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>>
+    {
+        Ok(AppendEntriesResponse::Success)
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        rpc: InstallSnapshotRequest<TypeConfig>,
+        _opt: RPCOption,
+    ) -> Result<
+        InstallSnapshotResponse<TypeConfig>,
+        RPCError<TypeConfig, RaftError<TypeConfig, InstallSnapshotError>>,
+    > {
+        Ok(InstallSnapshotResponse { vote: rpc.vote })
+    }
+
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<TypeConfig>,
+        _opt: RPCOption,
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>> {
+        Ok(VoteResponse::new(rpc.vote, rpc.last_log_id, true))
+    }
 }
 
-impl ConsensusState {
-    pub fn new() -> Self {
-        ConsensusState {
-            proposals: Arc::new(RwLock::new(HashMap::new())),
-            votes: Arc::new(RwLock::new(HashMap::new())),
-        }
-    }
+struct DummyNetworkFactory;
 
-    pub async fn add_proposal(&self, proposal: ConsensusProposal) {
-        let mut proposals = self.proposals.write().await;
-        proposals.insert(proposal.proposal_id, proposal.clone());
-        self.votes.write().await.insert(proposal.proposal_id, 0);
-        info!("Added new proposal: {:?}", proposal);
-    }
+#[async_trait]
+impl RaftNetworkFactory<TypeConfig> for DummyNetworkFactory {
+    type Network = DummyNetwork;
 
-    pub async fn cast_vote(&self, proposal_id: Uuid) {
-        let mut votes = self.votes.write().await;
-        if let Some(vote_count) = votes.get_mut(&proposal_id) {
-            *vote_count += 1;
-            info!("Cast vote for proposal: {}. Current votes: {}", proposal_id, *vote_count);
-        } else {
-            error!("Proposal not found: {}", proposal_id);
-        }
-    }
-
-    pub async fn has_consensus(&self, proposal_id: Uuid, threshold: usize) -> bool {
-        let votes = self.votes.read().await;
-        if let Some(&vote_count) = votes.get(&proposal_id) {
-            vote_count >= threshold
-        } else {
-            false
-        }
+    async fn new_client(&mut self, _target: NodeId, _node: &BasicNode) -> Self::Network {
+        DummyNetwork
     }
 }
 
 pub async fn run_consensus_protocol(
-    consensus_state: ConsensusState,
+    node_id: NodeId,
     mut proposal_rx: mpsc::Receiver<ConsensusProposal>,
-    mut vote_rx: broadcast::Receiver<Uuid>,
-    consensus_threshold: usize,
+    commit_tx: broadcast::Sender<String>,
 ) -> Result<(), Box<dyn Error>> {
-    loop {
-        tokio::select! {
-            Some(proposal) = proposal_rx.recv() => {
-                consensus_state.add_proposal(proposal).await;
+    let config = Arc::new(Config::default().validate()?);
+    let (log_store, state_machine) = new_mem_store();
+    let network = DummyNetworkFactory;
+    let raft = Raft::new(node_id, config, network, log_store, state_machine).await?;
+    let db: Db = sled::open(format!("raft-{}", node_id))?;
+
+    while let Some(p) = proposal_rx.recv().await {
+        let req = ClientRequest {
+            client: p.proposer_id.to_string(),
+            serial: 0,
+            status: p.content.clone(),
+        };
+        match raft.client_write(req).await {
+            Ok(res) => {
+                let _ = db.insert(
+                    res.log_id.to_string().as_bytes(),
+                    serde_json::to_vec(&res.data)?,
+                );
+                let _ = commit_tx.send(res.data.0.clone().unwrap_or_default());
+                info!("Committed proposal {}", p.proposal_id);
             }
-            Ok(proposal_id) = vote_rx.recv() => {
-                consensus_state.cast_vote(proposal_id).await;
-                if consensus_state.has_consensus(proposal_id, consensus_threshold).await {
-                    info!("Consensus reached for proposal: {}", proposal_id);
-                    // Handle the proposal that reached consensus (e.g., apply an update to the database)
-                }
-            }
-            Err(e) => {
-                error!("Failed to receive proposal or vote: {:?}", e);
-            }
+            Err(e) => error!("raft write error: {:?}", e),
         }
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add openraft and sled dependencies
- replace naive consensus with Raft-based replication placeholder

## Testing
- `pre-commit run --files Cargo.toml src/consensus.rs` *(fails: this file contains an unclosed delimiter in src/principal.rs; failed to select a version for openraft)*

------
https://chatgpt.com/codex/tasks/task_e_68b46efd1db4832895b771a3e147a41e