### PR TITLE
Refactor consensus module with structured state and dummy network

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -9,13 +9,6 @@ use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::{error, info};
 use uuid::Uuid;
 
-use serde::{Deserialize, Serialize};
-use std::error::Error;
-use std::sync::Arc;
-use tokio::sync::{broadcast, mpsc};
-use tracing::{error, info};
-use uuid::Uuid;
-
 use async_trait::async_trait;
 use openraft::error::{InstallSnapshotError, RPCError, RaftError};
 use openraft::network::{RPCOption, RaftNetwork, RaftNetworkFactory};
@@ -35,6 +28,45 @@ pub struct ConsensusProposal {
 }
 
 pub type NodeId = u64;
+/// Tracks proposals and votes in-memory.
+#[derive(Default)]
+struct ConsensusState {
+    proposals: RwLock<HashMap<Uuid, ConsensusProposal>>,
+    votes: RwLock<HashMap<Uuid, usize>>,
+}
+
+impl ConsensusState {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    async fn add_proposal(&self, proposal: ConsensusProposal) {
+        self.votes.write().await.insert(proposal.proposal_id, 0);
+        self.proposals
+            .write()
+            .await
+            .insert(proposal.proposal_id, proposal);
+        info!("Received proposal: {}", proposal.proposal_id);
+    }
+
+    async fn cast_vote(&self, proposal_id: Uuid) {
+        let mut votes = self.votes.write().await;
+        if let Some(vote_count) = votes.get_mut(&proposal_id) {
+            *vote_count += 1;
+            info!(
+                "Cast vote for proposal: {}. Current votes: {}",
+                proposal_id, *vote_count
+            );
+        } else {
+            error!("Proposal not found: {}", proposal_id);
+        }
+    }
+
+    async fn has_consensus(&self, proposal_id: Uuid, threshold: usize) -> bool {
+        let votes = self.votes.read().await;
+        matches!(votes.get(&proposal_id), Some(&count) if count >= threshold)
+    }
+}
 
 struct DummyNetwork;
 
@@ -42,11 +74,15 @@ struct DummyNetwork;
 impl RaftNetwork<TypeConfig> for DummyNetwork {
     async fn append_entries(
         &mut self,
-        _rpc: AppendEntriesRequest<TypeConfig>,
+        rpc: AppendEntriesRequest<TypeConfig>,
         _opt: RPCOption,
     ) -> Result<AppendEntriesResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>>
     {
-        Ok(AppendEntriesResponse::Success)
+        Ok(AppendEntriesResponse {
+            vote: rpc.vote,
+            success: true,
+            conflict: None,
+        })
     }
 
     async fn install_snapshot(
@@ -60,20 +96,15 @@ impl RaftNetwork<TypeConfig> for DummyNetwork {
         Ok(InstallSnapshotResponse { vote: rpc.vote })
     }
 
-
-    pub async fn cast_vote(&self, proposal_id: Uuid) {
-        let mut votes = self.votes.write().await;
-        if let Some(vote_count) = votes.get_mut(&proposal_id) {
-            *vote_count += 1;
-            info!(
-                "Cast vote for proposal: {}. Current votes: {}",
-                proposal_id, *vote_count
-            );
-        } else {
-            error!("Proposal not found: {}", proposal_id);
-        }
-
-
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<TypeConfig>,
+        _opt: RPCOption,
+    ) -> Result<VoteResponse<TypeConfig>, RPCError<TypeConfig, RaftError<TypeConfig>>> {
+        Ok(VoteResponse {
+            vote: rpc.vote,
+            vote_granted: true,
+        })
     }
 }
 
@@ -91,24 +122,11 @@ impl RaftNetworkFactory<TypeConfig> for DummyNetworkFactory {
 pub async fn run_consensus_protocol(
     node_id: NodeId,
     mut proposal_rx: mpsc::Receiver<ConsensusProposal>,
+    mut vote_rx: broadcast::Receiver<Uuid>,
     commit_tx: broadcast::Sender<String>,
+    consensus_threshold: usize,
 ) -> Result<(), Box<dyn Error>> {
-
-    loop {
-        tokio::select! {
-            Some(proposal) = proposal_rx.recv() => {
-                consensus_state.add_proposal(proposal).await;
-            }
-            Ok(proposal_id) = vote_rx.recv() => {
-                consensus_state.cast_vote(proposal_id).await;
-                if consensus_state.has_consensus(proposal_id, consensus_threshold).await {
-                    info!("Consensus reached for proposal: {}", proposal_id);
-                    logging_metrics::set_consensus_state(1.0);
-                    // Handle the proposal that reached consensus (e.g., apply an update to the database)
-                }
-            }
-            Err(e) => {
-                error!("Failed to receive proposal or vote: {:?}", e);
+    let consensus_state = ConsensusState::new();
 
     let config = Arc::new(Config::default().validate()?);
     let (log_store, state_machine) = new_mem_store();
@@ -116,23 +134,36 @@ pub async fn run_consensus_protocol(
     let raft = Raft::new(node_id, config, network, log_store, state_machine).await?;
     let db: Db = sled::open(format!("raft-{}", node_id))?;
 
-    while let Some(p) = proposal_rx.recv().await {
-        let req = ClientRequest {
-            client: p.proposer_id.to_string(),
-            serial: 0,
-            status: p.content.clone(),
-        };
-        match raft.client_write(req).await {
-            Ok(res) => {
-                let _ = db.insert(
-                    res.log_id.to_string().as_bytes(),
-                    serde_json::to_vec(&res.data)?,
-                );
-                let _ = commit_tx.send(res.data.0.clone().unwrap_or_default());
-                info!("Committed proposal {}", p.proposal_id);
+    loop {
+        tokio::select! {
+            Some(proposal) = proposal_rx.recv() => {
+                consensus_state.add_proposal(proposal.clone()).await;
 
+                let req = ClientRequest {
+                    client: proposal.proposer_id.to_string(),
+                    serial: 0,
+                    status: proposal.content.clone(),
+                };
+                match raft.client_write(req).await {
+                    Ok(res) => {
+                        let _ = db.insert(
+                            res.log_id.to_string().as_bytes(),
+                            serde_json::to_vec(&res.data)?,
+                        );
+                        let _ = commit_tx.send(res.data.0.clone().unwrap_or_default());
+                        info!("Committed proposal {}", proposal.proposal_id);
+                    }
+                    Err(e) => error!("raft write error: {:?}", e),
+                }
             }
-            Err(e) => error!("raft write error: {:?}", e),
+            Ok(proposal_id) = vote_rx.recv() => {
+                consensus_state.cast_vote(proposal_id).await;
+                if consensus_state.has_consensus(proposal_id, consensus_threshold).await {
+                    info!("Consensus reached for proposal: {}", proposal_id);
+                    logging_metrics::set_consensus_state(1.0);
+                }
+            }
+            else => break,
         }
     }
 


### PR DESCRIPTION
## Summary
- add `ConsensusState` for proposal and vote tracking
- implement proper `DummyNetwork` and factory for Raft
- streamline `run_consensus_protocol` to manage proposals, votes, and Raft commits

## Testing
- `cargo test` *(fails: failed to parse lock file at: /workspace/an-ki/Cargo.lock, duplicate key `name` in table `package`)*

------
https://chatgpt.com/codex/tasks/task_e_68b481f7e5008328b5a4aeb61c746bd9