### PR TITLE
Use NodeRole enum for role handling

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
-use uuid::Uuid;
-use serde::{Serialize, Deserialize};
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// Represents the kind of task being dispatched between nodes.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -22,10 +22,17 @@ pub struct Task {
     pub data: String,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum NodeRole {
+    Principal,
+    An,
+    Ki,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodeInfo {
     pub id: Uuid,
     pub address: Option<String>,
     pub last_seen: Option<DateTime<Utc>>,
-    pub role: String,
+    pub role: NodeRole,
 }

--- a/src/dht.rs
+++ b/src/dht.rs
@@ -51,21 +51,22 @@ impl Dht {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::NodeRole;
     use chrono::Utc;
 
-    fn sample_node(role: &str) -> NodeInfo {
+    fn sample_node(role: NodeRole) -> NodeInfo {
         NodeInfo {
             id: Uuid::new_v4(),
             address: None,
             last_seen: Some(Utc::now()),
-            role: role.to_string(),
+            role,
         }
     }
 
     #[tokio::test]
     async fn test_add_and_get_node() {
         let dht = Dht::new();
-        let node = sample_node("test");
+        let node = sample_node(NodeRole::An);
         let id = node.id;
         dht.add_node(node).await;
         let retrieved = dht.get_node(&id).await;
@@ -76,7 +77,7 @@ mod tests {
     #[tokio::test]
     async fn test_remove_node() {
         let dht = Dht::new();
-        let node = sample_node("test");
+        let node = sample_node(NodeRole::An);
         let id = node.id;
         dht.add_node(node).await;
         dht.remove_node(&id).await;
@@ -86,8 +87,8 @@ mod tests {
     #[tokio::test]
     async fn test_list_nodes() {
         let dht = Dht::new();
-        dht.add_node(sample_node("a")).await;
-        dht.add_node(sample_node("b")).await;
+        dht.add_node(sample_node(NodeRole::An)).await;
+        dht.add_node(sample_node(NodeRole::Ki)).await;
         let nodes = dht.list_nodes().await;
         assert_eq!(nodes.len(), 2);
     }

--- a/src/node_registry.rs
+++ b/src/node_registry.rs
@@ -8,8 +8,7 @@ use tokio::sync::RwLock;
 use tracing::{error, info};
 use uuid::Uuid;
 
-use crate::common::NodeInfo;
-
+use crate::common::{NodeInfo, NodeRole};
 
 #[derive(Clone)]
 pub struct NodeRegistry {
@@ -23,7 +22,7 @@ impl NodeRegistry {
         }
     }
 
-    pub async fn register_node(&self, node_id: Uuid, role: String) {
+    pub async fn register_node(&self, node_id: Uuid, role: NodeRole) {
         let node_info = NodeInfo {
             id: node_id,
             address: None,
@@ -67,12 +66,13 @@ impl NodeRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::NodeRole;
 
     #[tokio::test]
     async fn test_register_and_update_node() {
         let registry = NodeRegistry::new();
         let node_id = Uuid::new_v4();
-        let role = "teacher".to_string();
+        let role = NodeRole::An;
 
         registry.register_node(node_id, role.clone()).await;
         assert!(registry.get_node_info(&node_id).await.is_some());
@@ -86,7 +86,7 @@ mod tests {
     async fn test_remove_node() {
         let registry = NodeRegistry::new();
         let node_id = Uuid::new_v4();
-        let role = "ki".to_string();
+        let role = NodeRole::Ki;
 
         registry.register_node(node_id, role).await;
         assert!(registry.get_node_info(&node_id).await.is_some());
@@ -101,12 +101,8 @@ mod tests {
         let node_id_1 = Uuid::new_v4();
         let node_id_2 = Uuid::new_v4();
 
-        registry
-            .register_node(node_id_1, "teacher".to_string())
-            .await;
-        registry
-            .register_node(node_id_2, "ki".to_string())
-            .await;
+        registry.register_node(node_id_1, NodeRole::An).await;
+        registry.register_node(node_id_2, NodeRole::Ki).await;
 
         let active_nodes = registry.list_active_nodes().await;
         assert_eq!(active_nodes.len(), 2);

--- a/src/security.rs
+++ b/src/security.rs
@@ -18,11 +18,13 @@ use std::env;
 use std::error::Error;
 use tracing::info;
 
+use crate::common::NodeRole;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
-    pub sub: String,  // Subject (usually the node ID)
-    pub role: String, // Role of the node (e.g., principal, teacher, ki)
-    pub exp: usize,   // Expiration time as a UNIX timestamp
+    pub sub: String,    // Subject (usually the node ID)
+    pub role: NodeRole, // Role of the node (e.g., principal, an, ki)
+    pub exp: usize,     // Expiration time as a UNIX timestamp
 }
 
 fn get_secret_key() -> Result<String, env::VarError> {
@@ -31,13 +33,13 @@ fn get_secret_key() -> Result<String, env::VarError> {
 
 pub fn generate_token(
     node_id: &str,
-    role: &str,
+    role: NodeRole,
     expiration_minutes: i64,
 ) -> Result<String, Box<dyn Error>> {
     let expiration = Utc::now() + Duration::minutes(expiration_minutes);
     let claims = Claims {
         sub: node_id.to_owned(),
-        role: role.to_owned(),
+        role,
         exp: expiration.timestamp() as usize,
     };
 
@@ -48,8 +50,8 @@ pub fn generate_token(
         &EncodingKey::from_secret(secret_key.as_ref()),
     )?;
     info!(
-        "Generated token for node_id: {} with role: {}",
-        node_id, role
+        "Generated token for node_id: {} with role: {:?}",
+        node_id, claims.role
     );
     Ok(token)
 }
@@ -62,7 +64,7 @@ pub fn verify_token(token: &str) -> Result<TokenData<Claims>, Box<dyn Error>> {
         &Validation::default(),
     )?;
     info!(
-        "Verified token for node_id: {} with role: {}",
+        "Verified token for node_id: {} with role: {:?}",
         token_data.claims.sub, token_data.claims.role
     );
     Ok(token_data)
@@ -71,7 +73,7 @@ pub fn verify_token(token: &str) -> Result<TokenData<Claims>, Box<dyn Error>> {
 pub fn renew_token(token: &str, expiration_minutes: i64) -> Result<String, Box<dyn Error>> {
     let token_data = verify_token(token)?;
     let Claims { sub, role, .. } = &token_data.claims;
-    generate_token(sub, role, expiration_minutes)
+    generate_token(sub, role.clone(), expiration_minutes)
 }
 
 const SALT_LEN: usize = 16;
@@ -196,6 +198,7 @@ mod tests {
         decrypt_message, encrypt_message, generate_challenge, generate_token, renew_token,
         sign_challenge, validate_certificate, verify_challenge, verify_token, Claims,
     };
+    use crate::common::NodeRole;
     use rcgen::{
         BasicConstraints, Certificate as RcCertificate, CertificateParams, ExtendedKeyUsagePurpose,
         IsCa,
@@ -205,8 +208,8 @@ mod tests {
     fn test_generate_and_verify_token() {
         std::env::set_var("JWT_SECRET_KEY", "test_secret_key");
         let node_id = "test_node";
-        let role = "teacher";
-        let token = generate_token(node_id, role, 60).unwrap();
+        let role = NodeRole::An;
+        let token = generate_token(node_id, role.clone(), 60).unwrap();
         let token_data = verify_token(&token).unwrap();
         let Claims {
             sub,
@@ -241,7 +244,7 @@ mod tests {
     #[test]
     fn test_renew_token() {
         std::env::set_var("JWT_SECRET_KEY", "test_secret_key");
-        let token = generate_token("node", "role", 1).unwrap();
+        let token = generate_token("node", NodeRole::Ki, 1).unwrap();
         let renewed = renew_token(&token, 60).unwrap();
         let data = verify_token(&renewed).unwrap();
         assert_eq!(data.claims.sub, "node");


### PR DESCRIPTION
## Summary
- Define `NodeRole` enum for `Principal`, `An`, and `Ki`
- Replace string-based roles with `NodeRole` in registry and DHT tests
- Encode `NodeRole` in JWT claims and related auth helpers

## Testing
- `cargo test` *(fails: failed to parse lock file at: /workspace/an-ki/Cargo.lock)*

------
https://chatgpt.com/codex/tasks/task_e_68b4985d649c8328a2e0327fbe28c4d8