### PR TITLE
Add configurable OTLP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ export DATABASE_URL="postgresql://root@localhost:26257/defaultdb?sslmode=disable
    mkdir -p config
    cp config/default.example config/default.toml
    ```
-   Edit `config/default.toml` to set values for `amqp_addr`, `jwt_secret_key`, and `database_url`.
-   You can also supply the JWT secret via the `JWT_SECRET_KEY` environment variable if preferred.
+   Edit `config/default.toml` to set values for `amqp_addr`, `jwt_secret_key`, `database_url`,
+   and optionally `otlp_endpoint` to point to your OpenTelemetry collector
+   (default is `http://localhost:4317`). You can also supply the JWT secret via the
+   `JWT_SECRET_KEY` environment variable and the OTLP endpoint via `OTLP_ENDPOINT` if preferred.
 
 5. **Build the project:**
    Compile the project to ensure there are no issues.
@@ -239,8 +241,9 @@ docker run --rm -p 4317:4317 -p 9464:9464 \
   --config /etc/otel-collector-config.yaml
 ```
 
-Nodes export traces to the collector via OTLP on port `4317` and expose Prometheus metrics on port `9090`. The collector
-scrapes these metrics and re-exports them on `9464` for federation.
+Nodes export traces to the collector via OTLP on port `4317` (configurable via the
+`otlp_endpoint` setting or `OTLP_ENDPOINT` environment variable) and expose Prometheus metrics on port `9090`.
+The collector scrapes these metrics and re-exports them on `9464` for federation.
 
 ### Grafana Dashboard
 

--- a/config/default.example
+++ b/config/default.example
@@ -4,5 +4,6 @@
 amqp_addr = "amqp://127.0.0.1:5672/%2f"
 jwt_secret_key = "<JWT_SECRET_KEY>"
 database_url = "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+otlp_endpoint = "http://localhost:4317"
 model_shards = 1
 training_epochs = 10

--- a/config/default.toml
+++ b/config/default.toml
@@ -6,5 +6,6 @@
 amqp_addr = "amqp://127.0.0.1:5672/%2f"
 jwt_secret_key = "change-me"
 database_url = "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
+otlp_endpoint = "http://localhost:4317"
 model_shards = 1
 training_epochs = 10

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub struct Settings {
     pub amqp_addr: String,
     pub jwt_secret_key: String,
     pub database_url: String,
+    /// OTLP endpoint for exporting traces.
+    pub otlp_endpoint: Option<String>,
     /// Number of model shards expected when aggregating gradients.
     pub model_shards: usize,
     /// Number of training epochs the scheduler should execute.
@@ -40,6 +42,7 @@ impl Settings {
         override_from_env_or_file(&mut s, "amqp_addr", "AMQP_ADDR")?;
         override_from_env_or_file(&mut s, "jwt_secret_key", "JWT_SECRET_KEY")?;
         override_from_env_or_file(&mut s, "database_url", "DATABASE_URL")?;
+        override_from_env_or_file(&mut s, "otlp_endpoint", "OTLP_ENDPOINT")?;
 
         s.try_into()
     }
@@ -75,6 +78,7 @@ mod tests {
         assert!(!settings.amqp_addr.is_empty());
         assert!(!settings.jwt_secret_key.is_empty());
         assert!(!settings.database_url.is_empty());
+        assert!(settings.otlp_endpoint.is_some());
         assert!(settings.model_shards > 0);
         assert!(settings.training_epochs > 0);
     }

--- a/src/logging_metrics.rs
+++ b/src/logging_metrics.rs
@@ -9,6 +9,7 @@ use prometheus::{
     TextEncoder,
 };
 use std::convert::Infallible;
+use std::env;
 use std::time::Instant;
 use tracing::{debug, info};
 use tracing_opentelemetry::OpenTelemetryLayer;
@@ -38,9 +39,15 @@ lazy_static! {
 }
 
 pub fn init_logging() {
+    let endpoint = crate::config::load_settings()
+        .ok()
+        .and_then(|s| s.otlp_endpoint)
+        .or_else(|| env::var("OTLP_ENDPOINT").ok())
+        .unwrap_or_else(|| "http://localhost:4317".to_string());
+
     let exporter = SpanExporter::builder()
         .with_tonic()
-        .with_endpoint("http://localhost:4317")
+        .with_endpoint(endpoint)
         .build()
         .expect("failed to create OTLP exporter");
 


### PR DESCRIPTION
## Summary
- allow configuring OTLP exporter endpoint via settings or `OTLP_ENDPOINT`
- pull endpoint from configuration in `init_logging`
- document how to set OTLP endpoint

## Testing
- `pre-commit run --files README.md config/default.example config/default.toml src/config.rs src/logging_metrics.rs` *(fails: duplicate key `name` in Cargo.lock)*
- `cargo test` *(fails: duplicate key `name` in Cargo.lock)*

------
https://chatgpt.com/codex/tasks/task_e_68b4985b06d883289c897373ed4986a3