### PR TITLE
Include Channel type in lapin import

### DIFF
--- a/src/principal.rs
+++ b/src/principal.rs
@@ -5,7 +5,7 @@ use crate::signals;
 
 use crate::config::load_settings;
 use futures_util::stream::StreamExt;
-use lapin::{options::BasicAckOptions, Connection, ConnectionProperties};
+use lapin::{options::BasicAckOptions, Channel, Connection, ConnectionProperties};
 use std::error::Error;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;


### PR DESCRIPTION
## Summary
- add Channel to the lapin imports in principal so the channel type is available

## Testing
- `cargo check` *(fails: unresolved import crate::database in task_recovery.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a2a4eba8832899b42dbc41e84a5d