### PR TITLE
Use values when broadcasting tasks

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -78,8 +78,12 @@ impl Scheduler {
     /// Sends a task to every node managed by the scheduler.
     async fn broadcast_task(&self, task: Task) -> Result<(), Box<dyn Error>> {
         let nodes = self.load_balancer.nodes.read().await;
-        for node in nodes.iter() {
-            info!("Broadcasting task {} to node {}", task.task_id, node.node_id);
+        for info in nodes.values() {
+            info!(
+                "Broadcasting task {} to node {}",
+                task.task_id,
+                info.node_id
+            );
             self.task_tx
                 .send(task.clone())
                 .await


### PR DESCRIPTION
## Summary
- Iterate over node map values when broadcasting tasks
- Log correct node ID during task broadcast

## Testing
- `cargo +nightly -Znext-lockfile-bump check` *(fails: unresolved import `crate::database::PgPool` and mismatched types in `task_recovery.rs`)*
- `cargo +nightly -Znext-lockfile-bump check --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b5f90fd9388328a09342dae204dc58