### PR TITLE
Add module and API documentation for networking and scheduling components

### DIFF
--- a/src/load_balancer.rs
+++ b/src/load_balancer.rs
@@ -1,4 +1,8 @@
-// load_balancer.rs: Implements load balancing for An nodes to effectively distribute tasks.
+//! Load balancing for assigning work to nodes.
+//!
+//! The [`LoadBalancer`] maintains a set of active nodes and distributes work to the
+//! least loaded node. It uses a binary heap to efficiently choose candidates and
+//! exposes helpers for updating load information.
 
 use rand::seq::IteratorRandom;
 use std::cmp::Ordering;
@@ -9,9 +13,12 @@ use tokio::sync::RwLock;
 use tracing::{error, info};
 use uuid::Uuid;
 
+/// Stores the current task load for a node.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NodeLoadInfo {
+    /// Unique identifier of the node.
     pub node_id: Uuid,
+    /// Number of tasks currently assigned to the node.
     pub task_count: usize,
 }
 
@@ -31,9 +38,12 @@ impl PartialOrd for NodeLoadInfo {
     }
 }
 
+/// Coordinates task distribution among nodes.
 #[derive(Clone)]
 pub struct LoadBalancer {
+    /// Mapping of node identifiers to their load information.
     pub nodes: Arc<RwLock<HashMap<Uuid, NodeLoadInfo>>>,
+    /// Min-heap of nodes ordered by [`NodeLoadInfo::task_count`].
     pub heap: Arc<RwLock<BinaryHeap<NodeLoadInfo>>>,
 }
 
@@ -44,6 +54,7 @@ impl Default for LoadBalancer {
 }
 
 impl LoadBalancer {
+    /// Creates an empty [`LoadBalancer`].
     pub fn new() -> Self {
         LoadBalancer {
             nodes: Arc::new(RwLock::new(HashMap::new())),
@@ -51,6 +62,10 @@ impl LoadBalancer {
         }
     }
 
+    /// Registers a new node with zero initial load.
+    ///
+    /// # Parameters
+    /// * `node_id` - Identifier of the node to add.
     pub async fn add_node(&self, node_id: Uuid) {
         let mut nodes = self.nodes.write().await;
         let info = NodeLoadInfo {
@@ -64,6 +79,10 @@ impl LoadBalancer {
         info!("Added node to load balancer: {}", node_id);
     }
 
+    /// Removes a node from the balancer.
+    ///
+    /// # Parameters
+    /// * `node_id` - Identifier of the node to remove.
     pub async fn remove_node(&self, node_id: &Uuid) {
         let mut nodes = self.nodes.write().await;
         if nodes.remove(node_id).is_some() {
@@ -80,6 +99,11 @@ impl LoadBalancer {
         }
     }
 
+    /// Assigns a task to the least-loaded node.
+    ///
+    /// # Returns
+    /// * `Some(Uuid)` - Identifier of the chosen node.
+    /// * `None` - No nodes were available for assignment.
     pub async fn assign_task(&self) -> Option<Uuid> {
         loop {
             let candidate = {
@@ -116,6 +140,10 @@ impl LoadBalancer {
         }
     }
 
+    /// Decrements the load count for a node after task completion.
+    ///
+    /// # Parameters
+    /// * `node_id` - Identifier of the node whose load should decrease.
     pub async fn complete_task(&self, node_id: &Uuid) {
         let mut nodes = self.nodes.write().await;
         if let Some(entry) = nodes.get_mut(node_id) {
@@ -145,12 +173,21 @@ impl LoadBalancer {
         }
     }
 
+    /// Returns a random node identifier or `None` if the balancer is empty.
     pub async fn random_node(&self) -> Option<Uuid> {
         let nodes = self.nodes.read().await;
         nodes.keys().copied().choose(&mut rand::thread_rng())
     }
 }
 
+/// Updates the load balancer using load reports from nodes.
+///
+/// The function listens on `rx` for [`NodeLoadInfo`] messages and updates the
+/// balancer to reflect the reported task counts.
+///
+/// # Parameters
+/// * `rx` - Channel receiving load updates from nodes.
+/// * `load_balancer` - Shared load balancer to update.
 pub async fn monitor_node_load(
     mut rx: broadcast::Receiver<NodeLoadInfo>,
     load_balancer: LoadBalancer,

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,4 +1,8 @@
-// network.rs: Abstracts network operations such as connecting nodes and handling retries.
+//! Networking utilities for establishing TLS connections between nodes.
+//!
+//! The [`NetworkManager`] provides retrying connection logic and tracks peers that
+//! are currently connected. It is primarily used by higher level coordination
+//! components to ensure reliable communication between nodes.
 
 use std::collections::HashSet;
 use std::error::Error;
@@ -13,13 +17,21 @@ use tokio_rustls::{
 };
 use tracing::{error, info};
 
+/// Manages outbound connections to other nodes and maintains a set of peers that
+/// are currently reachable.
 #[derive(Clone, Debug)]
 pub struct NetworkManager {
+    /// Addresses of nodes that have been successfully contacted.
     pub connected_nodes: Arc<RwLock<HashSet<SocketAddr>>>,
+    /// TLS configuration used when connecting to remote nodes.
     tls_config: Arc<ClientConfig>,
 }
 
 impl NetworkManager {
+    /// Creates a new [`NetworkManager`] using the provided TLS client configuration.
+    ///
+    /// # Parameters
+    /// * `tls_config` - TLS settings used for all outbound connections.
     pub fn new(tls_config: ClientConfig) -> Self {
         NetworkManager {
             connected_nodes: Arc::new(RwLock::new(HashSet::new())),
@@ -27,6 +39,19 @@ impl NetworkManager {
         }
     }
 
+    /// Attempts to establish a TLS connection to `address`.
+    ///
+    /// # Parameters
+    /// * `address` - Socket address of the remote node.
+    /// * `domain` - DNS name expected in the remote TLS certificate.
+    /// * `retry_count` - Number of times to retry before giving up.
+    /// * `timeout_duration` - How long to wait for each connection attempt.
+    /// * `base_delay` - Initial delay before retrying.
+    /// * `max_backoff` - Maximum delay between retries.
+    ///
+    /// # Errors
+    /// Returns an error if a connection cannot be established after all retries
+    /// or if TLS negotiation fails.
     pub async fn connect_to_node(
         &self,
         address: SocketAddr,
@@ -79,6 +104,10 @@ impl NetworkManager {
         Err("Failed to connect after retries".into())
     }
 
+    /// Removes a node from the tracked set of connected peers.
+    ///
+    /// # Parameters
+    /// * `address` - Address of the node to disconnect.
     pub async fn disconnect_node(&self, address: &SocketAddr) {
         let mut nodes = self.connected_nodes.write().await;
         if nodes.remove(address) {
@@ -88,6 +117,7 @@ impl NetworkManager {
         }
     }
 
+    /// Returns a list of currently connected node addresses.
     pub async fn list_connected_nodes(&self) -> Vec<SocketAddr> {
         let nodes = self.connected_nodes.read().await;
         nodes.iter().cloned().collect()

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,13 +1,17 @@
-// scheduler.rs: Implements a task scheduler that assigns tasks to Ki nodes based on load and capacity.
+//! Task scheduling for distributing work among Ki nodes.
+//!
+//! The [`Scheduler`] coordinates training tasks by leveraging the [`LoadBalancer`]
+//! and dispatching work to available nodes according to the selected
+//! [`TrainingMode`].
 
-use crate::load_balancer::LoadBalancer;
 use crate::common::{Task, TaskType};
-use tokio::sync::mpsc;
-use uuid::Uuid;
-use tracing::{info, error};
-use std::time::Duration;
-use tokio::time;
+use crate::load_balancer::LoadBalancer;
 use std::error::Error;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::time;
+use tracing::{error, info};
+use uuid::Uuid;
 
 /// Specifies how the training tasks should be coordinated across nodes.
 #[derive(Clone, Copy)]
@@ -18,6 +22,7 @@ pub enum TrainingMode {
     AllReduce,
 }
 
+/// Coordinates the distribution of [`Task`]s to worker nodes.
 pub struct Scheduler {
     load_balancer: LoadBalancer,
     task_tx: mpsc::Sender<Task>,
@@ -26,7 +31,19 @@ pub struct Scheduler {
 }
 
 impl Scheduler {
-    pub fn new(load_balancer: LoadBalancer, task_tx: mpsc::Sender<Task>, mode: TrainingMode, epochs: u32) -> Self {
+    /// Creates a new scheduler.
+    ///
+    /// # Parameters
+    /// * `load_balancer` - Component used to select target nodes.
+    /// * `task_tx` - Channel used to dispatch tasks.
+    /// * `mode` - Training coordination strategy.
+    /// * `epochs` - Number of iterations to run in [`run_scheduler`].
+    pub fn new(
+        load_balancer: LoadBalancer,
+        task_tx: mpsc::Sender<Task>,
+        mode: TrainingMode,
+        epochs: u32,
+    ) -> Self {
         Scheduler {
             load_balancer,
             task_tx,
@@ -35,16 +52,21 @@ impl Scheduler {
         }
     }
 
+    /// Sends `task` to the least-loaded node.
+    ///
+    /// # Parameters
+    /// * `task` - The task to dispatch.
+    ///
+    /// # Errors
+    /// Returns an error if there are no nodes available or the channel send
+    /// operation fails.
     pub async fn schedule_task(&self, task: Task) -> Result<(), Box<dyn Error>> {
         if let Some(node_id) = self.load_balancer.assign_task().await {
             info!("Scheduling task {} to node {}", task.task_id, node_id);
-            self.task_tx
-                .send(task)
-                .await
-                .map_err(|e| {
-                    error!("Failed to send task: {:?}", e);
-                    e
-                })?;
+            self.task_tx.send(task).await.map_err(|e| {
+                error!("Failed to send task: {:?}", e);
+                e
+            })?;
             Ok(())
         } else {
             error!("No available nodes to schedule task {}");
@@ -52,10 +74,15 @@ impl Scheduler {
         }
     }
 
-    /// Runs the scheduler for a fixed number of epochs. In `ParameterServer` mode
-    /// a `ParameterPull` task is broadcast to all Ki nodes so they can fetch the
-    /// latest model from the An node. In `AllReduce` mode a `GradientUpdate` task is
-    /// broadcast which instructs nodes to compute gradients on their shard.
+    /// Runs the scheduler for a fixed number of `epochs`.
+    ///
+    /// In [`TrainingMode::ParameterServer`] a `ParameterPull` task is broadcast to
+    /// all nodes so they can fetch the latest model. In
+    /// [`TrainingMode::AllReduce`] a `GradientUpdate` task instructs nodes to
+    /// compute gradients on their shard.
+    ///
+    /// # Parameters
+    /// * `interval` - Delay between task broadcasts.
     pub async fn run_scheduler(&self, interval: Duration) {
         let mut ticker = time::interval(interval);
         for _ in 0..self.epochs {
@@ -81,16 +108,12 @@ impl Scheduler {
         for info in nodes.values() {
             info!(
                 "Broadcasting task {} to node {}",
-                task.task_id,
-                info.node_id
+                task.task_id, info.node_id
             );
-            self.task_tx
-                .send(task.clone())
-                .await
-                .map_err(|e| {
-                    error!("Failed to send task: {:?}", e);
-                    e
-                })?;
+            self.task_tx.send(task.clone()).await.map_err(|e| {
+                error!("Failed to send task: {:?}", e);
+                e
+            })?;
         }
         Ok(())
     }
@@ -106,7 +129,12 @@ mod tests {
     async fn test_schedule_task() {
         let load_balancer = LoadBalancer::new();
         let (task_tx, mut task_rx) = mpsc::channel(10);
-        let scheduler = Scheduler::new(load_balancer.clone(), task_tx, TrainingMode::ParameterServer, 1);
+        let scheduler = Scheduler::new(
+            load_balancer.clone(),
+            task_tx,
+            TrainingMode::ParameterServer,
+            1,
+        );
 
         load_balancer.add_node(Uuid::new_v4()).await;
         let task = Task {

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -1,4 +1,7 @@
-// task_recovery.rs: Implements task persistence and recovery for robustness.
+//! Task persistence and recovery utilities.
+//!
+//! The [`TaskRecoveryManager`] persists tasks to a PostgreSQL database so they can
+//! be restored after failures and tracks them in an in-memory map.
 
 use crate::common::{Task, TaskType};
 use crate::database::PgPool;
@@ -10,13 +13,20 @@ use uuid::Uuid;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
+/// Persists tasks to durable storage and reloads them on startup.
 #[derive(Clone)]
 pub struct TaskRecoveryManager {
+    /// In-memory cache of tasks keyed by ID.
     pub tasks: Arc<RwLock<HashMap<Uuid, Task>>>,
+    /// Database connection pool used for persistence operations.
     pub pool: PgPool,
 }
 
 impl TaskRecoveryManager {
+    /// Creates a new [`TaskRecoveryManager`].
+    ///
+    /// # Parameters
+    /// * `pool` - Connection pool for the tasks database.
     pub fn new(pool: PgPool) -> Self {
         TaskRecoveryManager {
             tasks: Arc::new(RwLock::new(HashMap::new())),
@@ -30,6 +40,13 @@ impl TaskRecoveryManager {
     /// the write lock is not held across an await. If persistence fails at any stage,
     /// the in-memory insertion is rolled back and an error is returned so callers can
     /// react accordingly.
+    ///
+    /// # Parameters
+    /// * `task` - Task to persist.
+    ///
+    /// # Errors
+    /// Returns an error if a database connection cannot be acquired or the insert
+    /// statement fails.
     pub async fn add_task(&self, task: Task) -> Result<(), Error> {
         let mut tasks = self.tasks.write().await;
         tasks.insert(task.task_id, task.clone());
@@ -67,6 +84,10 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
         Ok(())
     }
 
+    /// Removes a task from both memory and the database.
+    ///
+    /// # Parameters
+    /// * `task_id` - Identifier of the task to remove.
     pub async fn remove_task(&self, task_id: &Uuid) {
         let mut tasks = self.tasks.write().await;
         if tasks.remove(task_id).is_some() {
@@ -87,6 +108,10 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
         }
     }
 
+    /// Reloads all tasks from the database into memory.
+    ///
+    /// # Errors
+    /// Returns an error if the query to fetch tasks fails.
     pub async fn recover_tasks(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let conn = self.pool.get().await?;
         let rows = conn


### PR DESCRIPTION
## Summary
- document networking utilities and TLS connection management
- add usage docs for load balancer and scheduler modules
- describe task persistence and recovery behavior

## Testing
- `cargo doc --no-deps`
- `pre-commit run --files src/network.rs src/load_balancer.rs src/scheduler.rs src/task_recovery.rs` *(fails: clippy detected existing issues in unrelated code)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b75d1c9083288da3446b2892a3ca