### PR TITLE
Add messaging connection retry helper and refactor nodes

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -10,11 +10,10 @@ use crate::{
 use futures_util::stream::StreamExt;
 use lapin::{
     options::{BasicAckOptions, BasicNackOptions},
-    Channel, Consumer,
+    Channel,
 };
 use lazy_static::lazy_static;
 use tokio::sync::{oneshot, Mutex};
-use tokio::time::{sleep, Duration};
 use tracing::{error, info};
 use uuid::Uuid;
 
@@ -55,30 +54,16 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let queue_name = "an_task_queue";
     let consumer_tag = "an_consumer";
-    let mut attempts = 0u32;
 
     loop {
-        let (channel, mut consumer) =
-            match setup_consumer(&amqp_addr, queue_name, consumer_tag).await {
-                Ok(c) => {
-                    attempts = 0;
-                    c
-                }
-                Err(e) => {
-                    attempts += 1;
-                    error!(
-                        "Failed to establish connection: {:?}. Attempt {}/{}",
-                        e, attempts, max_retries
-                    );
-                    if attempts >= max_retries {
-                        error!("Exceeded maximum reconnection attempts. Exiting.");
-                        return Err(e);
-                    }
-                    let delay = backoff_ms * 2u64.pow(attempts - 1);
-                    sleep(Duration::from_millis(delay)).await;
-                    continue;
-                }
-            };
+        let (channel, mut consumer) = messaging::connect_with_retries(
+            &amqp_addr,
+            queue_name,
+            consumer_tag,
+            max_retries,
+            backoff_ms,
+        )
+        .await?;
 
         info!("An node is running and waiting for tasks...");
 
@@ -121,26 +106,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 }
             }
         }
-
-        attempts += 1;
-        if attempts >= max_retries {
-            error!("Failed to reconnect after {} attempts", max_retries);
-            return Err("reconnection attempts exceeded".into());
-        }
-        let delay = backoff_ms * 2u64.pow(attempts - 1);
-        sleep(Duration::from_millis(delay)).await;
     }
-}
-
-async fn setup_consumer(
-    amqp_addr: &str,
-    queue_name: &str,
-    consumer_tag: &str,
-) -> Result<(Channel, Consumer), Box<dyn Error>> {
-    let channel = messaging::establish_connection(amqp_addr).await?;
-    messaging::declare_queue(&channel, queue_name).await?;
-    let consumer = messaging::consume_messages(&channel, queue_name, consumer_tag).await?;
-    Ok((channel, consumer))
 }
 
 async fn process_task(
@@ -207,6 +173,7 @@ async fn broadcast_model(model: &[f32], channel: &Channel) -> Result<(), Box<dyn
 mod tests {
     use super::*;
     use crate::common::{Task, TaskType};
+    #[cfg(feature = "integration-tests")]
     use tokio::time::{timeout, Duration};
 
     #[tokio::test]
@@ -217,12 +184,6 @@ mod tests {
             data: serde_json::to_string(&vec![0.1_f32, 0.2_f32]).unwrap(),
         };
         assert!(process_task(task, None, 1).await.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_setup_consumer_failure() {
-        let result = setup_consumer("amqp://invalid:5672/%2f", "test_queue", "test_tag").await;
-        assert!(result.is_err());
     }
 
     #[cfg(feature = "integration-tests")]
@@ -237,9 +198,10 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn test_setup_consumer_workflow() {
-        let (channel, mut consumer) = setup_consumer(AMQP_ADDR, "test_queue", "test_consumer")
-            .await
-            .expect("setup");
+        let (channel, mut consumer) =
+            messaging::connect_with_retries(AMQP_ADDR, "test_queue", "test_consumer", 1, 10)
+                .await
+                .expect("setup");
 
         messaging::publish_message(&channel, "test_queue", b"hello")
             .await

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -6,10 +6,9 @@ use crate::config::load_settings;
 use crate::messaging;
 use crate::signals;
 use futures_util::stream::StreamExt;
-use lapin::{options::BasicAckOptions, Channel, Consumer};
+use lapin::{options::BasicAckOptions, Channel};
 use std::error::Error;
 use tokio::sync::oneshot;
-use tokio::time::{sleep, Duration};
 use tracing::{error, info};
 
 #[cfg(feature = "tch")]
@@ -46,31 +45,16 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let queue_name = "ki_task_queue";
     let consumer_tag = "ki_consumer";
-    let mut attempts = 0u32;
 
     loop {
-        // Establish connection and consumer using messaging helpers
-        let (channel, mut consumer) =
-            match setup_consumer(&amqp_addr, queue_name, consumer_tag).await {
-                Ok(c) => {
-                    attempts = 0; // reset attempts on success
-                    c
-                }
-                Err(e) => {
-                    attempts += 1;
-                    error!(
-                        "Failed to establish connection: {:?}. Attempt {}/{}",
-                        e, attempts, max_retries
-                    );
-                    if attempts >= max_retries {
-                        error!("Exceeded maximum reconnection attempts. Exiting.");
-                        return Err(e);
-                    }
-                    let delay = backoff_ms * 2u64.pow(attempts - 1);
-                    sleep(Duration::from_millis(delay)).await;
-                    continue;
-                }
-            };
+        let (channel, mut consumer) = messaging::connect_with_retries(
+            &amqp_addr,
+            queue_name,
+            consumer_tag,
+            max_retries,
+            backoff_ms,
+        )
+        .await?;
 
         info!("Ki node is running and waiting for tasks...");
 
@@ -107,37 +91,17 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                         }
                         Some(Err(e)) => {
                             error!("Error in consumer stream: {:?}", e);
-                            break; // reconnect
+                            break;
                         }
                         None => {
                             error!("Consumer stream closed");
-                            break; // reconnect
+                            break;
                         }
                     }
                 }
             }
         }
-
-        // Consumer ended; attempt to reconnect
-        attempts += 1;
-        if attempts > max_retries {
-            error!("Failed to reconnect after {} attempts", max_retries);
-            return Err("reconnection attempts exceeded".into());
-        }
-        let delay = backoff_ms * 2u64.pow(attempts - 1);
-        sleep(Duration::from_millis(delay)).await;
     }
-}
-
-async fn setup_consumer(
-    amqp_addr: &str,
-    queue_name: &str,
-    consumer_tag: &str,
-) -> Result<(Channel, Consumer), Box<dyn Error>> {
-    let channel = messaging::establish_connection(amqp_addr).await?;
-    messaging::declare_queue(&channel, queue_name).await?;
-    let consumer = messaging::consume_messages(&channel, queue_name, consumer_tag).await?;
-    Ok((channel, consumer))
 }
 
 async fn perform_computation(task: Task) -> Result<Task, Box<dyn Error>> {
@@ -193,12 +157,6 @@ async fn send_result(result: Task, channel: &Channel) -> Result<(), Box<dyn Erro
 mod tests {
     use super::*;
     use crate::common::{Task, TaskType};
-
-    #[tokio::test]
-    async fn test_setup_consumer_failure() {
-        let result = setup_consumer("amqp://invalid:5672/%2f", "queue", "tag").await;
-        assert!(result.is_err());
-    }
 
     #[tokio::test]
     async fn test_perform_computation_parameter_pull() {

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,14 +1,19 @@
 // messaging.rs: Implements RabbitMQ messaging logic, including sending and receiving messages across the network.
 
-use lapin::{options::*, types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties};
+use lapin::{
+    options::*, types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties,
+};
 use std::error::Error;
+use tokio::time::{sleep, Duration};
 use tracing::{error, info};
 
 pub async fn establish_connection(amqp_addr: &str) -> Result<Channel, Box<dyn Error>> {
-    let connection = Connection::connect(amqp_addr, ConnectionProperties::default()).await.map_err(|e| {
-        error!("Failed to connect to RabbitMQ: {:?}", e);
-        e
-    })?;
+    let connection = Connection::connect(amqp_addr, ConnectionProperties::default())
+        .await
+        .map_err(|e| {
+            error!("Failed to connect to RabbitMQ: {:?}", e);
+            e
+        })?;
     let channel = connection.create_channel().await.map_err(|e| {
         error!("Failed to create channel: {:?}", e);
         e
@@ -33,7 +38,11 @@ pub async fn declare_queue(channel: &Channel, queue_name: &str) -> Result<(), Bo
     Ok(())
 }
 
-pub async fn publish_message(channel: &Channel, queue_name: &str, payload: &[u8]) -> Result<(), Box<dyn Error>> {
+pub async fn publish_message(
+    channel: &Channel,
+    queue_name: &str,
+    payload: &[u8],
+) -> Result<(), Box<dyn Error>> {
     channel
         .basic_publish(
             "",
@@ -51,7 +60,11 @@ pub async fn publish_message(channel: &Channel, queue_name: &str, payload: &[u8]
     Ok(())
 }
 
-pub async fn consume_messages(channel: &Channel, queue_name: &str, consumer_tag: &str) -> Result<lapin::Consumer, Box<dyn Error>> {
+pub async fn consume_messages(
+    channel: &Channel,
+    queue_name: &str,
+    consumer_tag: &str,
+) -> Result<lapin::Consumer, Box<dyn Error>> {
     let consumer = channel
         .basic_consume(
             queue_name,
@@ -66,6 +79,42 @@ pub async fn consume_messages(channel: &Channel, queue_name: &str, consumer_tag:
         })?;
     info!("Started consuming messages from queue: {}", queue_name);
     Ok(consumer)
+}
+
+pub async fn connect_with_retries(
+    amqp_addr: &str,
+    queue_name: &str,
+    consumer_tag: &str,
+    max_retries: u32,
+    backoff_ms: u64,
+) -> Result<(Channel, lapin::Consumer), Box<dyn Error>> {
+    let mut attempts = 0u32;
+    loop {
+        let result = async {
+            let channel = establish_connection(amqp_addr).await?;
+            declare_queue(&channel, queue_name).await?;
+            let consumer = consume_messages(&channel, queue_name, consumer_tag).await?;
+            Ok::<_, Box<dyn Error>>((channel, consumer))
+        }
+        .await;
+
+        match result {
+            Ok(res) => return Ok(res),
+            Err(e) => {
+                attempts += 1;
+                error!(
+                    "Failed to establish connection: {:?}. Attempt {}/{}",
+                    e, attempts, max_retries
+                );
+                if attempts >= max_retries {
+                    error!("Exceeded maximum reconnection attempts.");
+                    return Err(e);
+                }
+                let delay = backoff_ms * 2u64.pow(attempts - 1);
+                sleep(Duration::from_millis(delay)).await;
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -110,16 +159,33 @@ mod tests {
 
         assert_eq!(delivery.data, b"hello");
 
-        delivery
-            .ack(BasicAckOptions::default())
-            .await
-            .expect("ack");
+        delivery.ack(BasicAckOptions::default()).await.expect("ack");
     }
 
     #[tokio::test]
     async fn test_connection_failure() {
         let result = establish_connection("amqp://invalid:5672/%2f").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_connect_with_retries_failure() {
+        let result = connect_with_retries("amqp://invalid:5672/%2f", "queue", "tag", 3, 10).await;
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "integration-tests")]
+    #[tokio::test]
+    async fn test_connect_with_retries_success() {
+        let res = connect_with_retries(AMQP_ADDR, "test_queue_retry", "test_tag", 1, 10).await;
+        match res {
+            Ok((channel, consumer)) => {
+                // drop consumer to close
+                drop(consumer);
+                drop(channel);
+            }
+            Err(_) => return, // skip if RabbitMQ not available
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add `connect_with_retries` helper in messaging for exponential backoff
- refactor An and Ki nodes to use retry helper
- test retry logic for failure and optional success paths

## Testing
- `cargo test` *(fails: pool: TimedOut in database and task_recovery tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b75b02888328a3399fdde8fb5e9e