### PR TITLE
feat: introduce AnKiError for clearer errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "sha2",
  "sled",
  "tch",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-postgres",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ tch = { version = "0.14", optional = true }
 openraft = { version = "0.9", features = ["serde"] }
 openraft-memstore = "0.9"
 sled = "0.34"
+thiserror = "1"
 
 [dev-dependencies]
 # Testing utilities

--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -137,9 +137,15 @@ async fn setup_consumer(
     queue_name: &str,
     consumer_tag: &str,
 ) -> Result<(Channel, Consumer), Box<dyn Error>> {
-    let channel = messaging::establish_connection(amqp_addr).await?;
-    messaging::declare_queue(&channel, queue_name).await?;
-    let consumer = messaging::consume_messages(&channel, queue_name, consumer_tag).await?;
+    let channel = messaging::establish_connection(amqp_addr)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
+    messaging::declare_queue(&channel, queue_name)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
+    let consumer = messaging::consume_messages(&channel, queue_name, consumer_tag)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
     Ok((channel, consumer))
 }
 
@@ -196,9 +202,13 @@ async fn broadcast_model(model: &[f32], channel: &Channel) -> Result<(), Box<dyn
         task_type: TaskType::ParameterPull,
         data: serde_json::to_string(model)?,
     };
-    messaging::declare_queue(channel, "ki_model_queue").await?;
+    messaging::declare_queue(channel, "ki_model_queue")
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
     let payload = serde_json::to_vec(&task)?;
-    messaging::publish_message(channel, "ki_model_queue", &payload).await?;
+    messaging::publish_message(channel, "ki_model_queue", &payload)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
     info!("Broadcasted model update");
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AnKiError {
+    #[error("Messaging error: {0}")]
+    Messaging(String),
+    #[error("Network error: {0}")]
+    Network(String),
+    #[error("Config error: {0}")]
+    Config(String),
+    #[error("Security error: {0}")]
+    Security(String),
+    #[error("Scheduler error: {0}")]
+    Scheduler(String),
+    #[error("Task recovery error: {0}")]
+    TaskRecovery(String),
+}

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -134,9 +134,15 @@ async fn setup_consumer(
     queue_name: &str,
     consumer_tag: &str,
 ) -> Result<(Channel, Consumer), Box<dyn Error>> {
-    let channel = messaging::establish_connection(amqp_addr).await?;
-    messaging::declare_queue(&channel, queue_name).await?;
-    let consumer = messaging::consume_messages(&channel, queue_name, consumer_tag).await?;
+    let channel = messaging::establish_connection(amqp_addr)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
+    messaging::declare_queue(&channel, queue_name)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
+    let consumer = messaging::consume_messages(&channel, queue_name, consumer_tag)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
     Ok((channel, consumer))
 }
 
@@ -184,7 +190,9 @@ async fn send_result(result: Task, channel: &Channel) -> Result<(), Box<dyn Erro
         e
     })?;
 
-    messaging::publish_message(channel, result_queue, &payload).await?;
+    messaging::publish_message(channel, result_queue, &payload)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
     info!("Sent result for task ID: {}", result.task_id);
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod network;
 pub mod signals;
 pub mod load_balancer;
 pub mod task_recovery;
+pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod principal;
 mod security;
 mod signals;
 mod task_recovery;
+mod error;
 
 #[tokio::main]
 async fn main() {

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,23 +1,25 @@
 // messaging.rs: Implements RabbitMQ messaging logic, including sending and receiving messages across the network.
 
 use lapin::{options::*, types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties};
-use std::error::Error;
 use tracing::{error, info};
+use crate::error::AnKiError;
 
-pub async fn establish_connection(amqp_addr: &str) -> Result<Channel, Box<dyn Error>> {
-    let connection = Connection::connect(amqp_addr, ConnectionProperties::default()).await.map_err(|e| {
-        error!("Failed to connect to RabbitMQ: {:?}", e);
-        e
-    })?;
+pub async fn establish_connection(amqp_addr: &str) -> Result<Channel, AnKiError> {
+    let connection = Connection::connect(amqp_addr, ConnectionProperties::default())
+        .await
+        .map_err(|e| {
+            error!("Failed to connect to RabbitMQ: {:?}", e);
+            AnKiError::Messaging(e.to_string())
+        })?;
     let channel = connection.create_channel().await.map_err(|e| {
         error!("Failed to create channel: {:?}", e);
-        e
+        AnKiError::Messaging(e.to_string())
     })?;
     info!("Established connection to RabbitMQ at: {}", amqp_addr);
     Ok(channel)
 }
 
-pub async fn declare_queue(channel: &Channel, queue_name: &str) -> Result<(), Box<dyn Error>> {
+pub async fn declare_queue(channel: &Channel, queue_name: &str) -> Result<(), AnKiError> {
     channel
         .queue_declare(
             queue_name,
@@ -27,13 +29,13 @@ pub async fn declare_queue(channel: &Channel, queue_name: &str) -> Result<(), Bo
         .await
         .map_err(|e| {
             error!("Failed to declare queue: {:?}", e);
-            e
+            AnKiError::Messaging(e.to_string())
         })?;
     info!("Declared queue: {}", queue_name);
     Ok(())
 }
 
-pub async fn publish_message(channel: &Channel, queue_name: &str, payload: &[u8]) -> Result<(), Box<dyn Error>> {
+pub async fn publish_message(channel: &Channel, queue_name: &str, payload: &[u8]) -> Result<(), AnKiError> {
     channel
         .basic_publish(
             "",
@@ -45,13 +47,17 @@ pub async fn publish_message(channel: &Channel, queue_name: &str, payload: &[u8]
         .await
         .map_err(|e| {
             error!("Failed to publish message: {:?}", e);
-            e
+            AnKiError::Messaging(e.to_string())
         })?;
     info!("Published message to queue: {}", queue_name);
     Ok(())
 }
 
-pub async fn consume_messages(channel: &Channel, queue_name: &str, consumer_tag: &str) -> Result<lapin::Consumer, Box<dyn Error>> {
+pub async fn consume_messages(
+    channel: &Channel,
+    queue_name: &str,
+    consumer_tag: &str,
+) -> Result<lapin::Consumer, AnKiError> {
     let consumer = channel
         .basic_consume(
             queue_name,
@@ -62,7 +68,7 @@ pub async fn consume_messages(channel: &Channel, queue_name: &str, consumer_tag:
         .await
         .map_err(|e| {
             error!("Failed to start consuming: {:?}", e);
-            e
+            AnKiError::Messaging(e.to_string())
         })?;
     info!("Started consuming messages from queue: {}", queue_name);
     Ok(consumer)

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,7 +1,6 @@
 // network.rs: Abstracts network operations such as connecting nodes and handling retries.
 
 use std::collections::HashSet;
-use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpStream;
@@ -12,6 +11,7 @@ use tokio_rustls::{
     TlsConnector,
 };
 use tracing::{error, info};
+use crate::error::AnKiError;
 
 #[derive(Clone, Debug)]
 pub struct NetworkManager {
@@ -35,14 +35,20 @@ impl NetworkManager {
         timeout_duration: Duration,
         base_delay: Duration,
         max_backoff: Duration,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), AnKiError> {
         for attempt in 0..retry_count {
             let connector = TlsConnector::from(self.tls_config.clone());
-            let domain_name = ServerName::try_from(domain).map_err(|e| format!("{e:?}"))?;
+            let domain_name = ServerName::try_from(domain)
+                .map_err(|e| AnKiError::Network(e.to_string()))?;
             let fut = async {
-                let tcp = TcpStream::connect(address).await?;
-                let _tls = connector.connect(domain_name, tcp).await?;
-                Ok::<(), Box<dyn Error>>(())
+                let tcp = TcpStream::connect(address)
+                    .await
+                    .map_err(|e| AnKiError::Network(e.to_string()))?;
+                let _tls = connector
+                    .connect(domain_name, tcp)
+                    .await
+                    .map_err(|e| AnKiError::Network(e.to_string()))?;
+                Ok::<(), AnKiError>(())
             };
 
             match timeout(timeout_duration, fut).await {
@@ -76,7 +82,7 @@ impl NetworkManager {
                 sleep(delay).await;
             }
         }
-        Err("Failed to connect after retries".into())
+        Err(AnKiError::Network("Failed to connect after retries".into()))
     }
 
     pub async fn disconnect_node(&self, address: &SocketAddr) {

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -61,10 +61,14 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     // Declare the queue for receiving update requests from An nodes
     let queue_name = "principal_update_queue";
-    declare_queue(&channel, queue_name).await?;
+    declare_queue(&channel, queue_name)
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
 
     // Start consuming update requests from the queue
-    let mut consumer = consume_messages(&channel, queue_name, "principal_consumer").await?;
+    let mut consumer = consume_messages(&channel, queue_name, "principal_consumer")
+        .await
+        .map_err(|e| Box::<dyn Error>::from(e))?;
 
     info!("Principal node is running and waiting for update requests...");
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use tracing::{info, error};
 use std::time::Duration;
 use tokio::time;
-use std::error::Error;
+use crate::error::AnKiError;
 
 /// Specifies how the training tasks should be coordinated across nodes.
 #[derive(Clone, Copy)]
@@ -35,7 +35,7 @@ impl Scheduler {
         }
     }
 
-    pub async fn schedule_task(&self, task: Task) -> Result<(), Box<dyn Error>> {
+    pub async fn schedule_task(&self, task: Task) -> Result<(), AnKiError> {
         if let Some(node_id) = self.load_balancer.assign_task().await {
             info!("Scheduling task {} to node {}", task.task_id, node_id);
             self.task_tx
@@ -43,12 +43,12 @@ impl Scheduler {
                 .await
                 .map_err(|e| {
                     error!("Failed to send task: {:?}", e);
-                    e
+                    AnKiError::Scheduler(e.to_string())
                 })?;
             Ok(())
         } else {
             error!("No available nodes to schedule task {}");
-            Err("No available nodes".into())
+            Err(AnKiError::Scheduler("No available nodes".into()))
         }
     }
 
@@ -76,7 +76,7 @@ impl Scheduler {
     }
 
     /// Sends a task to every node managed by the scheduler.
-    async fn broadcast_task(&self, task: Task) -> Result<(), Box<dyn Error>> {
+    async fn broadcast_task(&self, task: Task) -> Result<(), AnKiError> {
         let nodes = self.load_balancer.nodes.read().await;
         for info in nodes.values() {
             info!(
@@ -89,7 +89,7 @@ impl Scheduler {
                 .await
                 .map_err(|e| {
                     error!("Failed to send task: {:?}", e);
-                    e
+                    AnKiError::Scheduler(e.to_string())
                 })?;
         }
         Ok(())

--- a/src/security.rs
+++ b/src/security.rs
@@ -16,8 +16,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use webpki::{EndEntityCert, Time, TrustAnchor, ECDSA_P256_SHA256};
 
 use std::env;
-use std::error::Error;
 use tracing::info;
+use crate::error::AnKiError;
 
 use crate::common::NodeRole;
 
@@ -28,15 +28,15 @@ pub struct Claims {
     pub exp: usize,     // Expiration time as a UNIX timestamp
 }
 
-fn get_secret_key() -> Result<String, env::VarError> {
-    env::var("JWT_SECRET_KEY")
+fn get_secret_key() -> Result<String, AnKiError> {
+    env::var("JWT_SECRET_KEY").map_err(|e| AnKiError::Config(e.to_string()))
 }
 
 pub fn generate_token(
     node_id: &str,
     role: NodeRole,
     expiration_minutes: i64,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<String, AnKiError> {
     let expiration = Utc::now() + Duration::minutes(expiration_minutes);
     let claims = Claims {
         sub: node_id.to_owned(),
@@ -49,7 +49,8 @@ pub fn generate_token(
         &Header::default(),
         &claims,
         &EncodingKey::from_secret(secret_key.as_ref()),
-    )?;
+    )
+    .map_err(|e| AnKiError::Security(e.to_string()))?;
     info!(
         "Generated token for node_id: {} with role: {:?}",
         node_id, claims.role
@@ -57,13 +58,14 @@ pub fn generate_token(
     Ok(token)
 }
 
-pub fn verify_token(token: &str) -> Result<TokenData<Claims>, Box<dyn Error>> {
+pub fn verify_token(token: &str) -> Result<TokenData<Claims>, AnKiError> {
     let secret_key = get_secret_key()?;
     let token_data = decode::<Claims>(
         token,
         &DecodingKey::from_secret(secret_key.as_ref()),
         &Validation::default(),
-    )?;
+    )
+    .map_err(|e| AnKiError::Security(e.to_string()))?;
     info!(
         "Verified token for node_id: {} with role: {:?}",
         token_data.claims.sub, token_data.claims.role
@@ -71,7 +73,7 @@ pub fn verify_token(token: &str) -> Result<TokenData<Claims>, Box<dyn Error>> {
     Ok(token_data)
 }
 
-pub fn renew_token(token: &str, expiration_minutes: i64) -> Result<String, Box<dyn Error>> {
+pub fn renew_token(token: &str, expiration_minutes: i64) -> Result<String, AnKiError> {
     let token_data = verify_token(token)?;
     let Claims { sub, role, .. } = &token_data.claims;
     generate_token(sub, role.clone(), expiration_minutes)
@@ -81,7 +83,7 @@ const SALT_LEN: usize = 16;
 const NONCE_LEN: usize = 12;
 const PBKDF2_ITERATIONS: u32 = 100_000;
 
-pub fn encrypt_message(message: &str, key: &str) -> Result<String, Box<dyn Error>> {
+pub fn encrypt_message(message: &str, key: &str) -> Result<String, AnKiError> {
     // Generate a random salt for key derivation using a secure RNG
     let mut salt = [0u8; SALT_LEN];
     OsRng.fill_bytes(&mut salt);
@@ -106,7 +108,7 @@ pub fn encrypt_message(message: &str, key: &str) -> Result<String, Box<dyn Error
     // Encrypt the message
     let ciphertext = cipher
         .encrypt(nonce, message.as_bytes())
-        .map_err(|e| Box::<dyn Error>::from(e.to_string()))?;
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
 
     // Prepend salt and nonce to the ciphertext so they can be used for decryption
     let mut combined = Vec::with_capacity(SALT_LEN + NONCE_LEN + ciphertext.len());
@@ -117,11 +119,13 @@ pub fn encrypt_message(message: &str, key: &str) -> Result<String, Box<dyn Error
     Ok(general_purpose::STANDARD.encode(&combined))
 }
 
-pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, Box<dyn Error>> {
-    let decoded_bytes = general_purpose::STANDARD.decode(encoded_message)?;
+pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, AnKiError> {
+    let decoded_bytes = general_purpose::STANDARD
+        .decode(encoded_message)
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
 
     if decoded_bytes.len() < SALT_LEN + NONCE_LEN {
-        return Err("Invalid encrypted message".into());
+        return Err(AnKiError::Security("Invalid encrypted message".into()));
     }
 
     // Split salt, nonce, and ciphertext
@@ -143,27 +147,30 @@ pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, Box<d
     let nonce = Nonce::from_slice(nonce_bytes);
     let plaintext = cipher
         .decrypt(nonce, ciphertext)
-        .map_err(|e| Box::<dyn Error>::from(e.to_string()))?;
-    let decrypted_message = String::from_utf8(plaintext)?;
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
+    let decrypted_message = String::from_utf8(plaintext)
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
     Ok(decrypted_message)
 }
 
 /// Validates `cert_der` against the provided CA certificate `ca_der`.
-pub fn validate_certificate(cert_der: &[u8], ca_der: &[u8]) -> Result<(), Box<dyn Error>> {
-    let anchor = TrustAnchor::try_from_cert_der(ca_der).map_err(|e| e.to_string())?;
+pub fn validate_certificate(cert_der: &[u8], ca_der: &[u8]) -> Result<(), AnKiError> {
+    let anchor = TrustAnchor::try_from_cert_der(ca_der)
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
     let anchors = [anchor];
     let trust_anchors = webpki::TlsServerTrustAnchors(&anchors);
-    let cert = EndEntityCert::try_from(cert_der).map_err(|e| e.to_string())?;
+    let cert = EndEntityCert::try_from(cert_der)
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
     cert.verify_is_valid_tls_server_cert(
         &[&ECDSA_P256_SHA256],
         &trust_anchors,
         &[],
         Time::from_seconds_since_unix_epoch(now.as_secs()),
     )
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| AnKiError::Security(e.to_string()))?;
     Ok(())
 }
 
@@ -175,9 +182,12 @@ pub fn generate_challenge() -> [u8; 32] {
 }
 
 /// Signs the `challenge` using the node's private key in DER format.
-pub fn sign_challenge(challenge: &[u8], key_der: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
-    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, key_der)?;
-    let sig = key_pair.sign(&SystemRandom::new(), challenge)?;
+pub fn sign_challenge(challenge: &[u8], key_der: &[u8]) -> Result<Vec<u8>, AnKiError> {
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, key_der)
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
+    let sig = key_pair
+        .sign(&SystemRandom::new(), challenge)
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
     Ok(sig.as_ref().to_vec())
 }
 
@@ -186,10 +196,11 @@ pub fn verify_challenge(
     challenge: &[u8],
     signature: &[u8],
     cert_der: &[u8],
-) -> Result<(), Box<dyn Error>> {
-    let cert = EndEntityCert::try_from(cert_der).map_err(|e| e.to_string())?;
+) -> Result<(), AnKiError> {
+    let cert = EndEntityCert::try_from(cert_der)
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
     cert.verify_signature(&ECDSA_P256_SHA256, challenge, signature)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| AnKiError::Security(e.to_string()))?;
     Ok(())
 }
 

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -2,13 +2,12 @@
 
 use crate::common::{Task, TaskType};
 use crate::database::PgPool;
+use crate::error::AnKiError;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{error, info};
 use uuid::Uuid;
-
-type Error = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Clone)]
 pub struct TaskRecoveryManager {
@@ -30,7 +29,7 @@ impl TaskRecoveryManager {
     /// the write lock is not held across an await. If persistence fails at any stage,
     /// the in-memory insertion is rolled back and an error is returned so callers can
     /// react accordingly.
-    pub async fn add_task(&self, task: Task) -> Result<(), Error> {
+    pub async fn add_task(&self, task: Task) -> Result<(), AnKiError> {
         let mut tasks = self.tasks.write().await;
         tasks.insert(task.task_id, task.clone());
         info!("Added task to recovery manager: {:?}", task);
@@ -45,7 +44,7 @@ impl TaskRecoveryManager {
                 error!("Failed to acquire connection: {:?}", e);
                 let mut tasks = self.tasks.write().await;
                 tasks.remove(&task.task_id);
-                return Err(Box::new(e));
+                return Err(AnKiError::TaskRecovery(e.to_string()));
             }
         };
 
@@ -61,7 +60,7 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
             error!("Failed to persist task: {:?}", e);
             let mut tasks = self.tasks.write().await;
             tasks.remove(&task.task_id);
-            return Err(Box::new(e));
+            return Err(AnKiError::TaskRecovery(e.to_string()));
         }
 
         Ok(())
@@ -87,11 +86,16 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
         }
     }
 
-    pub async fn recover_tasks(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let conn = self.pool.get().await?;
+    pub async fn recover_tasks(&self) -> Result<(), AnKiError> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
         let rows = conn
             .query("SELECT task_id, task_type, data FROM tasks", &[])
-            .await?;
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
         let mut tasks = self.tasks.write().await;
         tasks.clear();
         for row in rows {


### PR DESCRIPTION
## Summary
- add thiserror and central `AnKiError` enum
- use `AnKiError` across messaging, network, scheduler, security, and task recovery modules
- adjust node modules to map new error type

## Testing
- `cargo test --no-run`
- `cargo test` *(fails: Failed to create pool: Timed out in bb8)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b752491c8328b245a22644008f9e