### PR TITLE
cache jwt secret with oncecell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
  "lapin",
  "lazy_static",
  "nix",
+ "once_cell",
  "openraft",
  "openraft-memstore",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ tch = { version = "0.14", optional = true }
 openraft = { version = "0.9", features = ["serde"] }
 openraft-memstore = "0.9"
 sled = "0.34"
+once_cell = "1"
 
 [dev-dependencies]
 # Testing utilities

--- a/src/security.rs
+++ b/src/security.rs
@@ -15,6 +15,7 @@ use std::num::NonZeroU32;
 use std::time::{SystemTime, UNIX_EPOCH};
 use webpki::{EndEntityCert, Time, TrustAnchor, ECDSA_P256_SHA256};
 
+use once_cell::sync::OnceCell;
 use std::env;
 use std::error::Error;
 use tracing::info;
@@ -28,8 +29,16 @@ pub struct Claims {
     pub exp: usize,     // Expiration time as a UNIX timestamp
 }
 
-fn get_secret_key() -> Result<String, env::VarError> {
-    env::var("JWT_SECRET_KEY")
+static JWT_SECRET_KEY: OnceCell<String> = OnceCell::new();
+
+fn get_secret_key() -> Result<&'static str, Box<dyn Error>> {
+    JWT_SECRET_KEY
+        .get_or_try_init(|| {
+            env::var("JWT_SECRET_KEY").map_err(|_| {
+                Box::<dyn Error>::from("JWT_SECRET_KEY environment variable is not set")
+            })
+        })
+        .map(|s| s.as_str())
 }
 
 pub fn generate_token(
@@ -48,7 +57,7 @@ pub fn generate_token(
     let token = encode(
         &Header::default(),
         &claims,
-        &EncodingKey::from_secret(secret_key.as_ref()),
+        &EncodingKey::from_secret(secret_key.as_bytes()),
     )?;
     info!(
         "Generated token for node_id: {} with role: {:?}",
@@ -61,7 +70,7 @@ pub fn verify_token(token: &str) -> Result<TokenData<Claims>, Box<dyn Error>> {
     let secret_key = get_secret_key()?;
     let token_data = decode::<Claims>(
         token,
-        &DecodingKey::from_secret(secret_key.as_ref()),
+        &DecodingKey::from_secret(secret_key.as_bytes()),
         &Validation::default(),
     )?;
     info!(
@@ -220,6 +229,7 @@ mod tests {
 
         assert_eq!(sub, node_id);
         assert_eq!(claim_role, role);
+        std::env::remove_var("JWT_SECRET_KEY");
     }
 
     #[test]
@@ -249,6 +259,7 @@ mod tests {
         let renewed = renew_token(&token, 60).unwrap();
         let data = verify_token(&renewed).unwrap();
         assert_eq!(data.claims.sub, "node");
+        std::env::remove_var("JWT_SECRET_KEY");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cache JWT secret key in a global `OnceCell`
- use cached key in token helpers
- ensure JWT secret env var is set and cleaned up in tests

## Testing
- `cargo test security::tests:: -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68b9b754e2588328a03cc79092df8c9e