### PR TITLE
Ensure logging initialization runs only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
  "lapin",
  "lazy_static",
  "nix",
+ "once_cell",
  "openraft",
  "openraft-memstore",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ rustls-pemfile = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 # Testing framework for lazy static initialization
 lazy_static = "1.4"
+once_cell = "1.19"
 tch = { version = "0.14", optional = true }
 openraft = { version = "0.9", features = ["serde"] }
 openraft-memstore = "0.9"

--- a/src/logging_metrics.rs
+++ b/src/logging_metrics.rs
@@ -1,6 +1,7 @@
 // logging_metrics.rs: Implements logging and metrics collection for monitoring node health and performance.
 
 use lazy_static::lazy_static;
+use once_cell::sync::OnceCell;
 use opentelemetry::{global, trace::TracerProvider as _};
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
@@ -38,37 +39,41 @@ lazy_static! {
     .unwrap();
 }
 
+static INIT: OnceCell<()> = OnceCell::new();
+
 pub fn init_logging() {
-    let endpoint = crate::config::load_settings()
-        .ok()
-        .and_then(|s| s.otlp_endpoint)
-        .or_else(|| env::var("OTLP_ENDPOINT").ok())
-        .unwrap_or_else(|| "http://localhost:4317".to_string());
+    INIT.get_or_init(|| {
+        let endpoint = crate::config::load_settings()
+            .ok()
+            .and_then(|s| s.otlp_endpoint)
+            .or_else(|| env::var("OTLP_ENDPOINT").ok())
+            .unwrap_or_else(|| "http://localhost:4317".to_string());
 
-    let exporter = SpanExporter::builder()
-        .with_tonic()
-        .with_endpoint(endpoint)
-        .build()
-        .expect("failed to create OTLP exporter");
+        let exporter = SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint)
+            .build()
+            .expect("failed to create OTLP exporter");
 
-    let processor = BatchSpanProcessor::builder(exporter).build();
-    let provider = SdkTracerProvider::builder()
-        .with_span_processor(processor)
-        .build();
+        let processor = BatchSpanProcessor::builder(exporter).build();
+        let provider = SdkTracerProvider::builder()
+            .with_span_processor(processor)
+            .build();
 
-    let tracer = provider.tracer("an-ki");
-    let otel_layer = OpenTelemetryLayer::new(tracer);
+        let tracer = provider.tracer("an-ki");
+        let otel_layer = OpenTelemetryLayer::new(tracer);
 
-    global::set_tracer_provider(provider);
+        global::set_tracer_provider(provider);
 
-    Registry::default()
-        .with(fmt::layer().with_target(false))
-        .with(EnvFilter::from_default_env())
-        .with(otel_layer)
-        .init();
+        Registry::default()
+            .with(fmt::layer().with_target(false))
+            .with(EnvFilter::from_default_env())
+            .with(otel_layer)
+            .init();
 
-    set_node_status(1.0);
-    info!("Logging initialized.");
+        set_node_status(1.0);
+        info!("Logging initialized.");
+    });
 }
 
 pub fn set_node_status(status: f64) {
@@ -106,23 +111,29 @@ pub async fn run_metrics_server() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
     use std::time::Duration;
-
-    #[test]
-    fn test_logging_initialization() {
+    static INIT: Lazy<()> = Lazy::new(|| {
         init_logging();
+    });
+
+    #[tokio::test]
+    async fn test_logging_initialization() {
+        Lazy::force(&INIT);
         info!("Testing logging initialization");
     }
 
     #[tokio::test]
     async fn test_metrics_endpoint() {
+        Lazy::force(&INIT);
         use warp::Reply;
         let response = metrics_endpoint().await.unwrap();
         assert!(response.into_response().status().is_success());
     }
 
-    #[test]
-    fn test_log_task_processing() {
+    #[tokio::test]
+    async fn test_log_task_processing() {
+        Lazy::force(&INIT);
         let start_time = Instant::now();
         std::thread::sleep(Duration::from_millis(100));
         log_task_processing(start_time);


### PR DESCRIPTION
## Summary
- add `once_cell` for one-time initialization helpers
- guard `init_logging` with a `OnceCell` so tracing setup executes once
- share logging setup in tests with a `Lazy` fixture and tokio

## Testing
- `cargo test` *(fails: database::tests::test_basic_query, database::tests::test_pool_creation, task_recovery::tests::test_add_and_update_task, task_recovery::tests::test_add_task_no_deadlock_on_slow_db, task_recovery::tests::test_recover_tasks_file_absent, task_recovery::tests::test_task_recovery)*
- `cargo test logging_metrics -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b9b753626883288f39c4bfc892d5db