### PR TITLE
Refactor An node state management

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -12,15 +12,89 @@ use lapin::{
     options::{BasicAckOptions, BasicNackOptions},
     Channel, Consumer,
 };
-use lazy_static::lazy_static;
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::oneshot;
 use tokio::time::{sleep, Duration};
 use tracing::{error, info};
 use uuid::Uuid;
 
-lazy_static! {
-    static ref MODEL_PARAMS: Mutex<Vec<f32>> = Mutex::new(Vec::new());
-    static ref GRAD_ACCUM: Mutex<(Vec<f32>, usize)> = Mutex::new((Vec::new(), 0));
+#[derive(Default)]
+pub struct AnNodeState {
+    model_params: Vec<f32>,
+    grad_accum: (Vec<f32>, usize),
+}
+
+impl AnNodeState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn process_task(
+        &mut self,
+        task: Task,
+        channel: Option<&Channel>,
+        shard_count: usize,
+    ) -> Result<(), Box<dyn Error>> {
+        match task.task_type {
+            TaskType::GradientUpdate => {
+                let gradient: Vec<f32> = serde_json::from_str(&task.data)?;
+                let broadcast_data = {
+                    if self.grad_accum.0.is_empty() {
+                        self.grad_accum.0 = vec![0.0; gradient.len()];
+                    }
+                    for (a, g) in self.grad_accum.0.iter_mut().zip(&gradient) {
+                        *a += g;
+                    }
+                    self.grad_accum.1 += 1;
+                    if self.grad_accum.1 >= shard_count {
+                        if self.model_params.is_empty() {
+                            self.model_params
+                                .resize(self.grad_accum.0.len(), 0.0);
+                        }
+                        for (m, a) in self
+                            .model_params
+                            .iter_mut()
+                            .zip(self.grad_accum.0.iter())
+                        {
+                            *m -= *a / shard_count as f32;
+                        }
+                        let model_clone = self.model_params.clone();
+                        self.grad_accum.0.iter_mut().for_each(|v| *v = 0.0);
+                        self.grad_accum.1 = 0;
+                        Some(model_clone)
+                    } else {
+                        None
+                    }
+                };
+                if let (Some(ch), Some(model)) = (channel, broadcast_data) {
+                    self.broadcast_model(&model, ch).await?;
+                }
+            }
+            TaskType::ParameterPull => {
+                if let Some(ch) = channel {
+                    let model = self.model_params.clone();
+                    self.broadcast_model(&model, ch).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn broadcast_model(
+        &self,
+        model: &[f32],
+        channel: &Channel,
+    ) -> Result<(), Box<dyn Error>> {
+        let task = Task {
+            task_id: Uuid::new_v4(),
+            task_type: TaskType::ParameterPull,
+            data: serde_json::to_string(model)?,
+        };
+        messaging::declare_queue(channel, "ki_model_queue").await?;
+        let payload = serde_json::to_vec(&task)?;
+        messaging::publish_message(channel, "ki_model_queue", &payload).await?;
+        info!("Broadcasted model update");
+        Ok(())
+    }
 }
 
 pub async fn run() -> Result<(), Box<dyn Error>> {
@@ -43,6 +117,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     })?;
     let amqp_addr = settings.amqp_addr.clone();
     let shard_count = settings.model_shards;
+    let mut state = AnNodeState::new();
 
     let max_retries: u32 = std::env::var("AMQP_RECONNECT_ATTEMPTS")
         .unwrap_or_else(|_| "5".into())
@@ -94,7 +169,10 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                             match serde_json::from_slice::<Task>(&delivery.data) {
                                 Ok(task_message) => {
                                     info!("Received task: {:?}", task_message);
-                                    if let Err(e) = process_task(task_message, Some(&channel), shard_count).await {
+                                    if let Err(e) = state
+                                        .process_task(task_message, Some(&channel), shard_count)
+                                        .await
+                                    {
                                         error!("Failed to process task: {:?}", e);
                                     }
                                     if let Err(e) = delivery.ack(BasicAckOptions::default()).await {
@@ -143,70 +221,11 @@ async fn setup_consumer(
     Ok((channel, consumer))
 }
 
-async fn process_task(
-    task: Task,
-    channel: Option<&Channel>,
-    shard_count: usize,
-) -> Result<(), Box<dyn Error>> {
-    match task.task_type {
-        TaskType::GradientUpdate => {
-            let gradient: Vec<f32> = serde_json::from_str(&task.data)?;
-            let broadcast_data = {
-                let mut acc = GRAD_ACCUM.lock().await;
-                if acc.0.is_empty() {
-                    acc.0 = vec![0.0; gradient.len()];
-                }
-                for (a, g) in acc.0.iter_mut().zip(&gradient) {
-                    *a += g;
-                }
-                acc.1 += 1;
-                if acc.1 >= shard_count {
-                    let mut model = MODEL_PARAMS.lock().await;
-                    if model.is_empty() {
-                        model.resize(acc.0.len(), 0.0);
-                    }
-                    for (m, a) in model.iter_mut().zip(acc.0.iter()) {
-                        *m -= *a / shard_count as f32;
-                    }
-                    let model_clone = model.clone();
-                    acc.0.iter_mut().for_each(|v| *v = 0.0);
-                    acc.1 = 0;
-                    Some(model_clone)
-                } else {
-                    None
-                }
-            };
-            if let (Some(ch), Some(model)) = (channel, broadcast_data) {
-                broadcast_model(&model, ch).await?;
-            }
-        }
-        TaskType::ParameterPull => {
-            if let Some(ch) = channel {
-                let model = MODEL_PARAMS.lock().await.clone();
-                broadcast_model(&model, ch).await?;
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn broadcast_model(model: &[f32], channel: &Channel) -> Result<(), Box<dyn Error>> {
-    let task = Task {
-        task_id: Uuid::new_v4(),
-        task_type: TaskType::ParameterPull,
-        data: serde_json::to_string(model)?,
-    };
-    messaging::declare_queue(channel, "ki_model_queue").await?;
-    let payload = serde_json::to_vec(&task)?;
-    messaging::publish_message(channel, "ki_model_queue", &payload).await?;
-    info!("Broadcasted model update");
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::common::{Task, TaskType};
+    #[cfg(feature = "integration-tests")]
     use tokio::time::{timeout, Duration};
 
     #[tokio::test]
@@ -216,7 +235,8 @@ mod tests {
             task_type: TaskType::GradientUpdate,
             data: serde_json::to_string(&vec![0.1_f32, 0.2_f32]).unwrap(),
         };
-        assert!(process_task(task, None, 1).await.is_ok());
+        let mut state = AnNodeState::new();
+        assert!(state.process_task(task, None, 1).await.is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- introduce `AnNodeState` to manage model parameters and gradient accumulation
- update `run` to use local state and delegate task processing
- adjust unit tests to operate on isolated node state

## Testing
- `cargo test` *(fails: pool: TimedOut in database and task recovery tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b75621908328a11c15ba81ae39e3