### PR TITLE
Add ciphertext length validation and error enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,18 @@
+use std::fmt;
+
+#[derive(Debug, PartialEq)]
+pub enum AnKiError {
+    InvalidCiphertext,
+    CryptoError(String),
+}
+
+impl fmt::Display for AnKiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AnKiError::InvalidCiphertext => write!(f, "Invalid ciphertext"),
+            AnKiError::CryptoError(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl std::error::Error for AnKiError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod network;
 pub mod signals;
 pub mod load_balancer;
 pub mod task_recovery;
+pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod principal;
 mod security;
 mod signals;
 mod task_recovery;
+mod error;
 
 #[tokio::main]
 async fn main() {

--- a/src/security.rs
+++ b/src/security.rs
@@ -20,6 +20,7 @@ use std::error::Error;
 use tracing::info;
 
 use crate::common::NodeRole;
+use crate::error::AnKiError;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
@@ -117,11 +118,13 @@ pub fn encrypt_message(message: &str, key: &str) -> Result<String, Box<dyn Error
     Ok(general_purpose::STANDARD.encode(&combined))
 }
 
-pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, Box<dyn Error>> {
-    let decoded_bytes = general_purpose::STANDARD.decode(encoded_message)?;
+pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, AnKiError> {
+    let decoded_bytes = general_purpose::STANDARD
+        .decode(encoded_message)
+        .map_err(|e| AnKiError::CryptoError(e.to_string()))?;
 
     if decoded_bytes.len() < SALT_LEN + NONCE_LEN {
-        return Err("Invalid encrypted message".into());
+        return Err(AnKiError::InvalidCiphertext);
     }
 
     // Split salt, nonce, and ciphertext
@@ -143,8 +146,9 @@ pub fn decrypt_message(encoded_message: &str, key: &str) -> Result<String, Box<d
     let nonce = Nonce::from_slice(nonce_bytes);
     let plaintext = cipher
         .decrypt(nonce, ciphertext)
-        .map_err(|e| Box::<dyn Error>::from(e.to_string()))?;
-    let decrypted_message = String::from_utf8(plaintext)?;
+        .map_err(|e| AnKiError::CryptoError(e.to_string()))?;
+    let decrypted_message = String::from_utf8(plaintext)
+        .map_err(|e| AnKiError::CryptoError(e.to_string()))?;
     Ok(decrypted_message)
 }
 
@@ -198,8 +202,11 @@ mod tests {
     use super::{
         decrypt_message, encrypt_message, generate_challenge, generate_token, renew_token,
         sign_challenge, validate_certificate, verify_challenge, verify_token, Claims,
+        NONCE_LEN, SALT_LEN,
     };
     use crate::common::NodeRole;
+    use crate::error::AnKiError;
+    use base64::{engine::general_purpose, Engine as _};
     use rcgen::{
         BasicConstraints, Certificate as RcCertificate, CertificateParams, ExtendedKeyUsagePurpose,
         IsCa,
@@ -240,6 +247,17 @@ mod tests {
 
         // Decryption should fail with an incorrect key
         assert!(decrypt_message(&encrypted_message1, "wrong_key").is_err());
+
+        // Truncated ciphertext should return InvalidCiphertext
+        let mut truncated = general_purpose::STANDARD
+            .decode(&encrypted_message1)
+            .unwrap();
+        truncated.truncate(SALT_LEN + NONCE_LEN - 1);
+        let truncated = general_purpose::STANDARD.encode(&truncated);
+        assert!(matches!(
+            decrypt_message(&truncated, key),
+            Err(AnKiError::InvalidCiphertext)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `AnKiError` enum to unify security errors
- validate ciphertext length before splitting and return `InvalidCiphertext`
- test decrypt failure on truncated ciphertext

## Testing
- `cargo test test_encrypt_and_decrypt_message -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b9b75975f88328b3520b25bd2b5152