### PR TITLE
Add lapin Consumer import for setup_consumer

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -11,6 +11,7 @@ use futures_util::stream::StreamExt;
 use lapin::{
     options::{BasicAckOptions, BasicNackOptions},
     Channel,
+    Consumer,
 };
 use lazy_static::lazy_static;
 use tokio::sync::{oneshot, Mutex};


### PR DESCRIPTION
## Summary
- import `Consumer` from lapin to support consumer setup in An node

## Testing
- `pre-commit run --files src/an_node.rs` *(fails: cannot find value `GRAD_ACCUM` and other compile errors)*
- `cargo check` *(fails: cannot find value `GRAD_ACCUM` and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f84b682483288d95d7249ac3cbce