### PR TITLE
Import tracing and uuid in scheduler

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -5,12 +5,13 @@
 //! [`TrainingMode`].
 
 use crate::common::{Task, TaskType};
+use crate::error::AnKiError;
 use crate::load_balancer::LoadBalancer;
-use std::error::Error;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time;
-use crate::error::AnKiError;
+use tracing::{error, info};
+use uuid::Uuid;
 
 /// Specifies how the training tasks should be coordinated across nodes.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary
- add tracing macros and UUID generation imports in scheduler
- clean up unused error import

## Testing
- `cargo test` *(fails: the size for values of type `[f32]` cannot be known at compilation time; missing `Consumer` type; `InvalidCiphertext` variant not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f84920fc8328844041fcbd26f288