### PR TITLE
Align migrations with Postgres types

### DIFF
--- a/migrations/001_create_tasks.sql
+++ b/migrations/001_create_tasks.sql
@@ -1,12 +1,7 @@
 CREATE TABLE IF NOT EXISTS tasks (
     task_id UUID PRIMARY KEY,
-    task_type STRING NOT NULL,
-    data STRING NOT NULL,
+    task_type TEXT NOT NULL,
+    data TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT now()
 );
 
--- Ensure column exists for deployments that ran the previous schema.
-ALTER TABLE tasks ADD COLUMN IF NOT EXISTS task_type STRING NOT NULL DEFAULT 'ParameterPull';
-
--- Configure replication across regions (requires enterprise features on real clusters).
-ALTER TABLE tasks CONFIGURE ZONE USING num_replicas = 3;

--- a/migrations/002_create_model_checkpoints.sql
+++ b/migrations/002_create_model_checkpoints.sql
@@ -1,8 +1,6 @@
 CREATE TABLE IF NOT EXISTS model_checkpoints (
     checkpoint_id UUID PRIMARY KEY,
     task_id UUID NOT NULL REFERENCES tasks(task_id),
-    checkpoint BYTES,
+    checkpoint BYTEA,
     created_at TIMESTAMPTZ DEFAULT now()
 );
-
-ALTER TABLE model_checkpoints CONFIGURE ZONE USING num_replicas = 3;


### PR DESCRIPTION
## Summary
- switch task-related string columns to TEXT and drop redundant Cockroach-specific statements
- update model checkpoint storage to use BYTEA and remove Cockroach-specific zone configuration

## Testing
- cargo test *(fails: database-related tests time out without a running PostgreSQL instance)*

------
https://chatgpt.com/codex/tasks/task_e_68d829d8af088328b411e00bf659fcaf