### PR TITLE
Handle missing task deletions gracefully

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -92,8 +92,14 @@ async fn delete_task_handler(
     task_id: Uuid,
     task_manager: Arc<TaskRecoveryManager>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    task_manager.remove_task(&task_id).await;
-    Ok(warp::reply::with_status("Task deleted", StatusCode::OK))
+    if task_manager.remove_task(&task_id).await {
+        Ok(warp::reply::with_status("Task deleted", StatusCode::OK))
+    } else {
+        Ok(warp::reply::with_status(
+            "Task not found",
+            StatusCode::NOT_FOUND,
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -165,5 +171,12 @@ mod tests {
             .reply(&api.filters())
             .await;
         assert_eq!(res.status(), StatusCode::OK);
+
+        let res = request()
+            .method("DELETE")
+            .path(&format!("/tasks/{}", task.task_id))
+            .reply(&api.filters())
+            .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -9,7 +9,7 @@ use crate::error::AnKiError;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -79,24 +79,30 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
     ///
     /// # Parameters
     /// * `task_id` - Identifier of the task to remove.
-    pub async fn remove_task(&self, task_id: &Uuid) {
+    pub async fn remove_task(&self, task_id: &Uuid) -> bool {
         let mut tasks = self.tasks.write().await;
-        if tasks.remove(task_id).is_some() {
-            info!("Removed task from recovery manager: {}", task_id);
-            match self.pool.get().await {
-                Ok(conn) => {
-                    if let Err(e) = conn
-                        .execute("DELETE FROM tasks WHERE task_id = $1", &[task_id])
-                        .await
-                    {
-                        error!("Failed to remove task from database: {:?}", e);
-                    }
-                }
-                Err(e) => error!("Failed to acquire connection: {:?}", e),
-            }
-        } else {
-            error!("Task not found for removal: {}", task_id);
+        let existed = tasks.remove(task_id).is_some();
+        drop(tasks);
+
+        if !existed {
+            debug!("Task not found for removal: {}", task_id);
+            return false;
         }
+
+        info!("Removed task from recovery manager: {}", task_id);
+        match self.pool.get().await {
+            Ok(conn) => {
+                if let Err(e) = conn
+                    .execute("DELETE FROM tasks WHERE task_id = $1", &[task_id])
+                    .await
+                {
+                    error!("Failed to remove task from database: {:?}", e);
+                }
+            }
+            Err(e) => error!("Failed to acquire connection: {:?}", e),
+        }
+
+        true
     }
 
     pub async fn recover_tasks(&self) -> Result<(), AnKiError> {


### PR DESCRIPTION
## Summary
- make `TaskRecoveryManager::remove_task` return a boolean and log missing tasks at debug level
- return HTTP 404 from the delete task handler when the task does not exist
- extend the delete task API test to cover the not-found response

## Testing
- cargo test *(fails: timed out acquiring Postgres connections in existing database-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d829dddf948328869a74cdc194f794