### PR TITLE
Handle JSON output for non-tch Ki gradient updates

### DIFF
--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -123,10 +123,13 @@ async fn perform_computation(task: Task) -> Result<Task, Box<dyn Error>> {
             }
             #[cfg(not(feature = "tch"))]
             {
+                let input: Vec<f32> = serde_json::from_str(&task.data)?;
+                let grad: Vec<f32> = input.into_iter().map(|v| v * 2.0).collect();
+                let data = serde_json::to_string(&grad)?;
                 Ok(Task {
                     task_id: task.task_id,
                     task_type: TaskType::GradientUpdate,
-                    data: format!("Processed data: {}", task.data),
+                    data,
                 })
             }
         }
@@ -159,6 +162,8 @@ async fn send_result(result: Task, channel: &Channel) -> Result<(), Box<dyn Erro
 mod tests {
     use super::*;
     use crate::common::{Task, TaskType};
+    #[cfg(not(feature = "tch"))]
+    use crate::an_node::AnNodeState;
 
     #[tokio::test]
     async fn test_perform_computation_parameter_pull() {
@@ -170,6 +175,34 @@ mod tests {
         let result = perform_computation(task.clone()).await.unwrap();
         assert_eq!(result.task_type, TaskType::ParameterPull);
         assert_eq!(result.task_id, task.task_id);
+    }
+
+    #[cfg(not(feature = "tch"))]
+    #[tokio::test]
+    async fn test_perform_computation_gradient_update_non_tch() {
+        let task = Task {
+            task_id: uuid::Uuid::new_v4(),
+            task_type: TaskType::GradientUpdate,
+            data: serde_json::to_string(&vec![1.0_f32, -0.5_f32]).unwrap(),
+        };
+        let result = perform_computation(task.clone()).await.unwrap();
+        assert_eq!(result.task_id, task.task_id);
+        assert_eq!(result.task_type, TaskType::GradientUpdate);
+        let gradient: Vec<f32> = serde_json::from_str(&result.data).unwrap();
+        assert_eq!(gradient, vec![2.0_f32, -1.0_f32]);
+    }
+
+    #[cfg(not(feature = "tch"))]
+    #[tokio::test]
+    async fn test_an_node_processes_ki_payload() {
+        let task = Task {
+            task_id: uuid::Uuid::new_v4(),
+            task_type: TaskType::GradientUpdate,
+            data: serde_json::to_string(&vec![0.25_f32, 0.5_f32]).unwrap(),
+        };
+        let result = perform_computation(task).await.unwrap();
+        let mut state = AnNodeState::new();
+        assert!(state.process_task(result, None, 1).await.is_ok());
     }
 
     #[cfg(feature = "integration-tests")]


### PR DESCRIPTION
## Summary
- deserialize non-tch gradient inputs, apply the dummy transform, and serialize the results back to JSON so the payload matches the tch implementation
- add unit tests covering the non-tch gradient path and verifying the An node can parse the generated payload

## Testing
- `cargo test test_perform_computation_gradient_update_non_tch -- --nocapture`
- `cargo test` *(fails: database connection pool creation times out in tests that require a live Postgres instance)*

------
https://chatgpt.com/codex/tasks/task_e_68d829d9dbec8328b83ff6bcf94872b9