### PR TITLE
Clarify AMQP reconnect semantics, reject zero attempts, normalize env and add boundary tests

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -16,6 +16,21 @@ use tokio::sync::oneshot;
 use tracing::{error, info};
 use uuid::Uuid;
 
+fn normalized_reconnect_attempts() -> u32 {
+    let raw = std::env::var("AMQP_RECONNECT_ATTEMPTS")
+        .unwrap_or_else(|_| "5".into())
+        .parse()
+        .unwrap_or(5);
+    if raw == 0 {
+        error!(
+            "AMQP_RECONNECT_ATTEMPTS=0 is invalid for retry semantics; normalizing to 1 total attempt."
+        );
+        1
+    } else {
+        raw
+    }
+}
+
 #[derive(Default)]
 pub struct AnNodeState {
     model_params: Vec<f32>,
@@ -113,10 +128,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     let shard_count = settings.model_shards;
     let mut state = AnNodeState::new();
 
-    let max_retries: u32 = std::env::var("AMQP_RECONNECT_ATTEMPTS")
-        .unwrap_or_else(|_| "5".into())
-        .parse()
-        .unwrap_or(5);
+    let max_retries: u32 = normalized_reconnect_attempts();
     let backoff_ms: u64 = std::env::var("AMQP_RECONNECT_BACKOFF_MS")
         .unwrap_or_else(|_| "500".into())
         .parse()
@@ -194,6 +206,27 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     use tokio::time::{timeout, Duration};
 
+    #[test]
+    fn test_normalized_reconnect_attempts_zero_is_one() {
+        std::env::set_var("AMQP_RECONNECT_ATTEMPTS", "0");
+        assert_eq!(normalized_reconnect_attempts(), 1);
+        std::env::remove_var("AMQP_RECONNECT_ATTEMPTS");
+    }
+
+    #[test]
+    fn test_normalized_reconnect_attempts_one_is_one() {
+        std::env::set_var("AMQP_RECONNECT_ATTEMPTS", "1");
+        assert_eq!(normalized_reconnect_attempts(), 1);
+        std::env::remove_var("AMQP_RECONNECT_ATTEMPTS");
+    }
+
+    #[test]
+    fn test_normalized_reconnect_attempts_high_value_is_preserved() {
+        std::env::set_var("AMQP_RECONNECT_ATTEMPTS", "100");
+        assert_eq!(normalized_reconnect_attempts(), 100);
+        std::env::remove_var("AMQP_RECONNECT_ATTEMPTS");
+    }
+
     #[tokio::test]
     async fn test_process_task_ok() {
         let task = Task {
@@ -225,8 +258,8 @@ mod tests {
             10,
             10_000,
         )
-                .await
-                .expect("setup");
+        .await
+        .expect("setup");
 
         messaging::publish_message(&channel, "test_queue", b"hello")
             .await

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -11,6 +11,21 @@ use std::error::Error;
 use tokio::sync::oneshot;
 use tracing::{error, info};
 
+fn normalized_reconnect_attempts() -> u32 {
+    let raw = std::env::var("AMQP_RECONNECT_ATTEMPTS")
+        .unwrap_or_else(|_| "5".into())
+        .parse()
+        .unwrap_or(5);
+    if raw == 0 {
+        error!(
+            "AMQP_RECONNECT_ATTEMPTS=0 is invalid for retry semantics; normalizing to 1 total attempt."
+        );
+        1
+    } else {
+        raw
+    }
+}
+
 #[derive(Default)]
 struct KiNodeState {
     model_params: Vec<f32>,
@@ -57,10 +72,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     })?;
 
     let amqp_addr = settings.amqp_addr;
-    let max_retries: u32 = std::env::var("AMQP_RECONNECT_ATTEMPTS")
-        .unwrap_or_else(|_| "5".into())
-        .parse()
-        .unwrap_or(5);
+    let max_retries: u32 = normalized_reconnect_attempts();
     let backoff_ms: u64 = std::env::var("AMQP_RECONNECT_BACKOFF_MS")
         .unwrap_or_else(|_| "500".into())
         .parse()
@@ -231,9 +243,30 @@ async fn send_result(result: Task, channel: &Channel) -> Result<(), Box<dyn Erro
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::{Task, TaskType};
     #[cfg(not(feature = "tch"))]
     use crate::an_node::AnNodeState;
+    use crate::common::{Task, TaskType};
+
+    #[test]
+    fn test_normalized_reconnect_attempts_zero_is_one() {
+        std::env::set_var("AMQP_RECONNECT_ATTEMPTS", "0");
+        assert_eq!(normalized_reconnect_attempts(), 1);
+        std::env::remove_var("AMQP_RECONNECT_ATTEMPTS");
+    }
+
+    #[test]
+    fn test_normalized_reconnect_attempts_one_is_one() {
+        std::env::set_var("AMQP_RECONNECT_ATTEMPTS", "1");
+        assert_eq!(normalized_reconnect_attempts(), 1);
+        std::env::remove_var("AMQP_RECONNECT_ATTEMPTS");
+    }
+
+    #[test]
+    fn test_normalized_reconnect_attempts_high_value_is_preserved() {
+        std::env::set_var("AMQP_RECONNECT_ATTEMPTS", "100");
+        assert_eq!(normalized_reconnect_attempts(), 100);
+        std::env::remove_var("AMQP_RECONNECT_ATTEMPTS");
+    }
 
     #[test]
     fn test_update_model_parameters() {

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,10 +1,12 @@
 // messaging.rs: Implements RabbitMQ messaging logic, including sending and receiving messages across the network.
 
-use lapin::{options::*, types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties};
+use crate::error::AnKiError;
+use lapin::{
+    options::*, types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties,
+};
 use std::error::Error;
 use tokio::time::{sleep, Duration};
 use tracing::{error, info};
-use crate::error::AnKiError;
 
 pub async fn establish_connection(amqp_addr: &str) -> Result<Channel, AnKiError> {
     let connection = Connection::connect(amqp_addr, ConnectionProperties::default())
@@ -37,7 +39,11 @@ pub async fn declare_queue(channel: &Channel, queue_name: &str) -> Result<(), An
     Ok(())
 }
 
-pub async fn publish_message(channel: &Channel, queue_name: &str, payload: &[u8]) -> Result<(), AnKiError> {
+pub async fn publish_message(
+    channel: &Channel,
+    queue_name: &str,
+    payload: &[u8],
+) -> Result<(), AnKiError> {
     channel
         .basic_publish(
             "",
@@ -84,8 +90,13 @@ pub async fn connect_with_retries(
     backoff_ms: u64,
     max_delay_ms: u64,
 ) -> Result<(Channel, lapin::Consumer), Box<dyn Error>> {
-    let mut attempts = 0u32;
-    loop {
+    if max_retries == 0 {
+        return Err(Box::new(AnKiError::Messaging(
+            "AMQP reconnect attempts must be >= 1".to_string(),
+        )));
+    }
+
+    for attempt in 1..=max_retries {
         let result = async {
             let channel = establish_connection(amqp_addr).await?;
             declare_queue(&channel, queue_name).await?;
@@ -97,24 +108,35 @@ pub async fn connect_with_retries(
         match result {
             Ok(res) => return Ok(res),
             Err(e) => {
-                attempts += 1;
                 error!(
-                    "Failed to establish connection: {:?}. Attempt {}/{}",
-                    e, attempts, max_retries
+                    "Failed to establish AMQP connection for queue '{}' (attempt {}/{}): {:?}",
+                    queue_name, attempt, max_retries, e
                 );
-                if attempts >= max_retries {
-                    error!("Exceeded maximum reconnection attempts.");
+                if attempt == max_retries {
+                    error!(
+                        "Exhausted AMQP connection attempts for queue '{}' after {} total attempt(s).",
+                        queue_name, max_retries
+                    );
                     return Err(e);
                 }
-                let attempt_factor = attempts.saturating_sub(1);
+                let attempt_factor = attempt.saturating_sub(1);
                 let multiplier = 2u64.saturating_pow(attempt_factor);
-                let delay = backoff_ms
-                    .saturating_mul(multiplier)
-                    .min(max_delay_ms);
+                let delay = backoff_ms.saturating_mul(multiplier).min(max_delay_ms);
+                info!(
+                    "Retrying AMQP connection for queue '{}' in {} ms (next attempt {}/{}).",
+                    queue_name,
+                    delay,
+                    attempt + 1,
+                    max_retries
+                );
                 sleep(Duration::from_millis(delay)).await;
             }
         }
     }
+
+    Err(Box::new(AnKiError::Messaging(
+        "AMQP connection retry loop exited unexpectedly".to_string(),
+    )))
 }
 
 #[cfg(test)]
@@ -170,15 +192,37 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_with_retries_failure() {
-        let result = connect_with_retries("amqp://invalid:5672/%2f", "queue", "tag", 3, 10, 20)
-            .await;
+        let result =
+            connect_with_retries("amqp://invalid:5672/%2f", "queue", "tag", 3, 10, 20).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_connect_with_retries_hits_max_delay_without_panic() {
-        let result = connect_with_retries("amqp://invalid:5672/%2f", "queue", "tag", 5, 4, 8)
-            .await;
+        let result = connect_with_retries("amqp://invalid:5672/%2f", "queue", "tag", 5, 4, 8).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_connect_with_retries_rejects_zero_attempts() {
+        let result =
+            connect_with_retries("amqp://127.0.0.1:1/%2f", "queue", "tag", 0, 10, 20).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("must be >= 1"));
+    }
+
+    #[tokio::test]
+    async fn test_connect_with_retries_one_attempt_has_no_retry_sleep() {
+        let start = std::time::Instant::now();
+        let result =
+            connect_with_retries("amqp://127.0.0.1:1/%2f", "queue", "tag", 1, 5_000, 5_000).await;
+        assert!(result.is_err());
+        assert!(start.elapsed() < Duration::from_millis(1_000));
+    }
+
+    #[tokio::test]
+    async fn test_connect_with_retries_high_attempt_count_still_fails_cleanly() {
+        let result = connect_with_retries("amqp://127.0.0.1:1/%2f", "queue", "tag", 20, 0, 0).await;
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
### Motivation

- Make `connect_with_retries` semantics explicit so callers and ops understand what `max_retries` means and avoid surprising behavior when `0` is provided.
- Prevent silent misconfiguration when `AMQP_RECONNECT_ATTEMPTS=0` is set in the environment by normalizing/validating at call sites.
- Improve logs so they clearly state which attempt is running, the affected queue, the planned retry delay, and when attempts are exhausted.

### Description

- In `src/messaging.rs` changed `connect_with_retries` to treat `max_retries` as the total number of connection attempts, validate and reject `max_retries == 0` with a clear error, iterate with `for attempt in 1..=max_retries`, and add explicit logging for attempt/queue context, upcoming retry delay, and exhaustion.
- Added an early-return error path in `connect_with_retries` for `0` and an unexpected-loop-exit error message to make control flow explicit.
- In `src/an_node.rs` and `src/ki_node.rs` added `normalized_reconnect_attempts()` that reads `AMQP_RECONNECT_ATTEMPTS`, coerces `0` to `1` (and logs), and replaced direct env parsing with the normalized value before calling `connect_with_retries`.
- Added unit tests: messaging tests for `max_retries = 0`, `1`, and high counts and timing/behavior assertions; caller-side tests in `an_node` and `ki_node` to assert normalization of `AMQP_RECONNECT_ATTEMPTS` for `0`, `1`, and a large value.

### Testing

- Ran the messaging retry unit tests with `cargo test test_connect_with_retries`, and the targeted tests passed (`test_connect_with_retries_rejects_zero_attempts`, `test_connect_with_retries_one_attempt_has_no_retry_sleep`, `test_connect_with_retries_high_attempt_count_still_fails_cleanly` among others).
- Ran the normalization unit tests with `cargo test normalized_reconnect_attempts`, and the `an_node`/`ki_node` normalization tests passed.
- Ran the repository test suite (`cargo test`), and the new tests executed and completed successfully in the CI/dev run shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17e06c61c83289e069fe39678c47e)