### PR TITLE
Handle malformed principal queue payloads without terminating consumer loop

### DIFF
--- a/src/principal.rs
+++ b/src/principal.rs
@@ -30,6 +30,20 @@ struct UpdateRequest {
     content: UpdateContent,
 }
 
+fn decode_update_request(payload: &[u8]) -> Option<UpdateRequest> {
+    match serde_json::from_slice::<UpdateRequest>(payload) {
+        Ok(update_request) => Some(update_request),
+        Err(e) => {
+            error!(
+                "Failed to deserialize update request payload. error={:?}, payload={}",
+                e,
+                String::from_utf8_lossy(payload)
+            );
+            None
+        }
+    }
+}
+
 pub async fn run() -> Result<(), Box<dyn Error>> {
     #[cfg(unix)]
     if let Err(e) = signals::setup_unix_signal_handlers().await {
@@ -86,10 +100,20 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             delivery_result = consumer.next() => {
                 match delivery_result {
                     Some(Ok(delivery)) => {
-                        let update_request: UpdateRequest = serde_json::from_slice(&delivery.data).map_err(|e| {
-                            error!("Failed to deserialize update request: {:?}", e);
-                            e
-                        })?;
+                        let Some(update_request) = decode_update_request(&delivery.data) else {
+                            // Queue policy: acknowledge malformed payloads so poison messages are dropped.
+                            delivery
+                                .ack(BasicAckOptions::default())
+                                .await
+                                .map_err(|e| {
+                                    error!(
+                                        "Failed to acknowledge malformed message for drop: {:?}",
+                                        e
+                                    );
+                                    e
+                                })?;
+                            continue;
+                        };
 
                         info!("Received update request: {:?}", update_request);
 
@@ -106,7 +130,8 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                             })?;
                     }
                     Some(Err(e)) => {
-                        error!("Failed to receive delivery: {:?}", e);
+                        error!("Failed to receive delivery (unrecoverable): {:?}", e);
+                        return Err(Box::new(e));
                     }
                     None => break,
                 }
@@ -223,5 +248,21 @@ mod tests {
         };
 
         assert!(process_update_request(update).await.is_err());
+    }
+
+    #[test]
+    fn decode_update_request_invalid_payload_does_not_block_following_payload() {
+        let invalid_payload = br#"{"update_id": "broken", "content": {"type":"database","data":{"statement":"X"}}"#;
+        let valid_payload =
+            br#"{"update_id":"5","content":{"type":"database","data":{"statement":"UPDATE t SET v=2"}}}"#;
+
+        let first = decode_update_request(invalid_payload);
+        let second = decode_update_request(valid_payload);
+
+        assert!(first.is_none(), "invalid payload should be dropped");
+        assert!(
+            second.is_some(),
+            "subsequent valid payload should still be decodable"
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent a single malformed JSON message from terminating the principal consumer loop and causing a restart or outage.
- Make parsing failures recoverable at the message level while still treating infrastructure delivery errors as unrecoverable.

### Description
- Added `decode_update_request(payload: &[u8]) -> Option<UpdateRequest>` which logs parse error details and returns `None` on failure instead of propagating an error.
- Replaced the `serde_json::from_slice(...)?` propagation in `run()` with a `match`/`if let` that uses `decode_update_request` and, on parse failure, logs the error + payload, `ack`s the delivery (drop per queue policy), and `continue`s the loop.
- Changed handling of consumer delivery errors so `Some(Err(e))` is treated as an unrecoverable infrastructure error that returns from `run()`, while data/processing errors remain non-fatal to the loop.
- Added a focused unit test `decode_update_request_invalid_payload_does_not_block_following_payload` that verifies an invalid payload is dropped and a subsequent valid payload is still decodable.

### Testing
- Ran `cargo test decode_update_request_invalid_payload_does_not_block_following_payload -- --nocapture`, and the test passed.
- Ran `cargo test principal::tests::process_update_request`, and the suite of `process_update_request` tests passed (4 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17e03e8b083289789d50a56c53bc9)