### PR TITLE
Add async-trait dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ name = "distributed_neural_network"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "async-trait",
  "base64 0.21.7",
  "bb8",
  "bb8-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tch = ["dep:tch"]
 # Async runtime
 tokio = { version = "1", features = ["full", "signal"] }
 tokio-util = { version = "0.7" }
+async-trait = "0.1"
 
 # Message passing (RabbitMQ)
 lapin = "2.0"


### PR DESCRIPTION
### Motivation
- `src/consensus.rs` uses the `async_trait` macro and relied on a transitive dependency; adding an explicit dependency avoids build breakage if upstream re-exports change. 
- The consensus module was not added to `src/lib.rs` or `src/main.rs` because it is not referenced elsewhere in the current build.

### Description
- Add `async-trait = "0.1"` to `[dependencies]` in `Cargo.toml` so `async_trait` is available to `src/consensus.rs`.
- `Cargo.lock` was updated to record the direct dependency; no source code or module declarations were modified.

### Testing
- Ran `cargo check` which completed successfully (warnings only).
- Ran `cargo check --lib` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21af97888328984fda13f59d6184)