### PR TITLE
Fix runtime config paths in Dockerfiles

### DIFF
--- a/Dockerfile.an
+++ b/Dockerfile.an
@@ -11,5 +11,7 @@ RUN cargo build --release
 FROM debian:bookworm-slim
 WORKDIR /app
 COPY --from=builder /app/target/release/distributed_neural_network /usr/local/bin/an-ki
-COPY config/default.toml /config/default.toml
+RUN mkdir -p /app/config
+COPY config/default.toml /app/config/default.toml
+COPY config/default.example /app/config/default.example
 CMD ["an-ki", "an"]

--- a/Dockerfile.ki
+++ b/Dockerfile.ki
@@ -11,5 +11,7 @@ RUN cargo build --release
 FROM debian:bookworm-slim
 WORKDIR /app
 COPY --from=builder /app/target/release/distributed_neural_network /usr/local/bin/an-ki
-COPY config/default.toml /config/default.toml
+RUN mkdir -p /app/config
+COPY config/default.toml /app/config/default.toml
+COPY config/default.example /app/config/default.example
 CMD ["an-ki", "ki"]

--- a/Dockerfile.principal
+++ b/Dockerfile.principal
@@ -11,5 +11,7 @@ RUN cargo build --release
 FROM debian:bookworm-slim
 WORKDIR /app
 COPY --from=builder /app/target/release/distributed_neural_network /usr/local/bin/an-ki
-COPY config/default.toml /config/default.toml
+RUN mkdir -p /app/config
+COPY config/default.toml /app/config/default.toml
+COPY config/default.example /app/config/default.example
 CMD ["an-ki", "principal"]


### PR DESCRIPTION
### Motivation
- Ensure the application can find its default configuration when the container runs with `WORKDIR /app` by providing the `config` directory under `/app` in runtime images. 
- Preserve the existing fallback behavior that reads `config/default.example` so `Settings::new` can still fall back if `default.toml` is absent.

### Description
- Updated `Dockerfile.an`, `Dockerfile.ki`, and `Dockerfile.principal` to `RUN mkdir -p /app/config` and `COPY config/default.toml /app/config/default.toml` and `COPY config/default.example /app/config/default.example` in the runtime stage. 
- Left the builder stages unchanged and only modified the runtime images so the binary remains at `/usr/local/bin/an-ki` while runtime config files live at `/app/config`. 
- Verified that `Settings::new` in `src/config.rs` loads `config/default.toml` relative to the process `WORKDIR` and falls back to `config/default.example` when needed.

### Testing
- Ran `git diff --check` which showed no whitespace or diff issues. 
- Ran `cargo test config::tests::test_load_settings` which passed and confirmed the runtime config path is resolvable by `Settings::new`. 
- Ran the full `cargo test` where config tests passed but 6 database-backed tests failed due to connection timeouts in this environment, and the Docker CLI was not available to build images (`docker` not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21ac23b483289185b1c1c469e0db)