### PR TITLE
Wait for RabbitMQ publisher confirms

### DIFF
--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -2,7 +2,10 @@
 
 use crate::error::AnKiError;
 use lapin::{
-    options::*, types::FieldTable, BasicProperties, Channel, Connection, ConnectionProperties,
+    options::*,
+    publisher_confirm::{Confirmation, PublisherConfirm},
+    types::FieldTable,
+    BasicProperties, Channel, Connection, ConnectionProperties,
 };
 use std::error::Error;
 use tokio::time::{sleep, Duration};
@@ -19,6 +22,13 @@ pub async fn establish_connection(amqp_addr: &str) -> Result<Channel, AnKiError>
         error!("Failed to create channel: {:?}", e);
         AnKiError::Messaging(e.to_string())
     })?;
+    channel
+        .confirm_select(ConfirmSelectOptions::default())
+        .await
+        .map_err(|e| {
+            error!("Failed to enable publisher confirms: {:?}", e);
+            AnKiError::Messaging(e.to_string())
+        })?;
     info!("Established connection to RabbitMQ at: {}", amqp_addr);
     Ok(channel)
 }
@@ -44,7 +54,7 @@ pub async fn publish_message(
     queue_name: &str,
     payload: &[u8],
 ) -> Result<(), AnKiError> {
-    channel
+    let confirm: PublisherConfirm = channel
         .basic_publish(
             "",
             queue_name,
@@ -57,8 +67,28 @@ pub async fn publish_message(
             error!("Failed to publish message: {:?}", e);
             AnKiError::Messaging(e.to_string())
         })?;
-    info!("Published message to queue: {}", queue_name);
-    Ok(())
+
+    match confirm.await.map_err(|e| {
+        error!("Failed to confirm published message: {:?}", e);
+        AnKiError::Messaging(e.to_string())
+    })? {
+        Confirmation::Ack(_) => {
+            info!("Published message to queue: {}", queue_name);
+            Ok(())
+        }
+        Confirmation::Nack(_) => {
+            let msg = format!("RabbitMQ negatively acknowledged publish to queue: {queue_name}");
+            error!("{}", msg);
+            Err(AnKiError::Messaging(msg))
+        }
+        Confirmation::NotRequested => {
+            let msg = format!(
+                "RabbitMQ publisher confirms were not enabled for publish to queue: {queue_name}"
+            );
+            error!("{}", msg);
+            Err(AnKiError::Messaging(msg))
+        }
+    }
 }
 
 pub async fn consume_messages(


### PR DESCRIPTION
### Motivation

- Ensure producers wait for broker acceptance so publishes aren’t treated as successful until RabbitMQ ACKs them.
- Surface broker-side negative acknowledgements and confirmation failures as `AnKiError::Messaging` to make publish errors actionable.
- Preserve existing publish call sites so `send_result`, model broadcasts, and other paths now observe broker acceptance without changes.

### Description

- Enable publisher confirms on new channels by calling `channel.confirm_select(ConfirmSelectOptions::default())` in `establish_connection`.
- Update `publish_message` to store the result of `channel.basic_publish(...).await?` in a `PublisherConfirm`, then `await` that future instead of returning immediately.
- Map confirmation outcomes so that `Confirmation::Ack(_)` returns success and `Confirmation::Nack(_)` or `Confirmation::NotRequested`, as well as confirmation/future errors, are converted to `AnKiError::Messaging`.
- Add the `lapin::publisher_confirm::{Confirmation, PublisherConfirm}` import and keep all existing callers unchanged so they now implicitly wait for broker acceptance.

### Testing

- Ran `cargo test messaging`, which passed (messaging-focused tests succeeded).
- Ran `cargo test`, which surfaced unrelated failures in PostgreSQL-backed database/task recovery tests due to local DB pool timeouts; these failures are not related to the messaging changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21b815b083288116edbdd7f1af40)