### PR TITLE
Add database fallback task lookup

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -52,9 +52,8 @@ async fn get_task_handler(
     task_id: Uuid,
     task_manager: Arc<TaskRecoveryManager>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    let tasks = task_manager.tasks.read().await;
-    if let Some(task) = tasks.get(&task_id) {
-        match serde_json::to_string(task) {
+    match task_manager.get_task(&task_id).await {
+        Ok(Some(task)) => match serde_json::to_string(&task) {
             Ok(body) => Ok(warp::reply::with_status(body, StatusCode::OK)),
             Err(e) => {
                 error!("Failed to serialize task: {}", e);
@@ -63,12 +62,18 @@ async fn get_task_handler(
                     StatusCode::INTERNAL_SERVER_ERROR,
                 ))
             }
-        }
-    } else {
-        Ok(warp::reply::with_status(
+        },
+        Ok(None) => Ok(warp::reply::with_status(
             "Task not found".to_string(),
             StatusCode::NOT_FOUND,
-        ))
+        )),
+        Err(e) => {
+            error!("Failed to get task: {:?}", e);
+            Ok(warp::reply::with_status(
+                "Internal server error".to_string(),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ))
+        }
     }
 }
 
@@ -156,6 +161,45 @@ mod tests {
             .await;
         assert_eq!(res.status(), StatusCode::OK);
         assert!(task_manager.remove_task(&task.task_id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_get_task_from_database_on_cache_miss() {
+        let pool = get_pool().await.expect("pool");
+        let task_manager = Arc::new(TaskRecoveryManager::new(pool.clone()));
+        let api = Api::new(task_manager.clone());
+
+        let task = Task {
+            task_id: Uuid::new_v4(),
+            task_type: TaskType::GradientUpdate,
+            data: "Database-backed task".to_string(),
+        };
+        let task_type = format!("{:?}", task.task_type);
+
+        pool.get()
+            .await
+            .unwrap()
+            .execute(
+                "INSERT INTO tasks (task_id, task_type, data) VALUES ($1,$2,$3)",
+                &[&task.task_id, &task_type, &task.data],
+            )
+            .await
+            .unwrap();
+
+        let res = request()
+            .method("GET")
+            .path(&format!("/tasks/{}", task.task_id))
+            .reply(&api.filters())
+            .await;
+        assert_eq!(res.status(), StatusCode::OK);
+        assert!(task_manager.tasks.read().await.contains_key(&task.task_id));
+
+        pool.get()
+            .await
+            .unwrap()
+            .execute("DELETE FROM tasks WHERE task_id = $1", &[&task.task_id])
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -12,6 +12,17 @@ use tokio::sync::RwLock;
 use tracing::{debug, error, info};
 use uuid::Uuid;
 
+fn task_type_from_str(task_type: &str, task_id: &Uuid) -> Option<TaskType> {
+    match task_type {
+        "GradientUpdate" => Some(TaskType::GradientUpdate),
+        "ParameterPull" => Some(TaskType::ParameterPull),
+        other => {
+            error!("Unknown task_type '{}' for task {}", other, task_id);
+            None
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct TaskRecoveryManager {
     /// In-memory cache of tasks keyed by ID.
@@ -75,6 +86,52 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
         Ok(())
     }
 
+    /// Looks up a task by ID, first checking memory and then falling back to the database.
+    ///
+    /// When the task is found in the database, the in-memory cache is repopulated
+    /// before returning a clone of the recovered task.
+    ///
+    /// # Parameters
+    /// * `task_id` - Identifier of the task to retrieve.
+    pub async fn get_task(&self, task_id: &Uuid) -> Result<Option<Task>, AnKiError> {
+        if let Some(task) = self.tasks.read().await.get(task_id).cloned() {
+            return Ok(Some(task));
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
+        let row = conn
+            .query_opt(
+                "SELECT task_id, task_type, data FROM tasks WHERE task_id = $1",
+                &[task_id],
+            )
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        let task_id: Uuid = row.get("task_id");
+        let task_type_str: String = row.get("task_type");
+        let data: String = row.get("data");
+        let Some(task_type) = task_type_from_str(&task_type_str, &task_id) else {
+            return Ok(None);
+        };
+        let task = Task {
+            task_id,
+            task_type,
+            data,
+        };
+
+        self.tasks.write().await.insert(task.task_id, task.clone());
+
+        Ok(Some(task))
+    }
+
     /// Removes a task from both memory and the database.
     ///
     /// # Parameters
@@ -133,13 +190,8 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
             let task_id: Uuid = row.get("task_id");
             let task_type_str: String = row.get("task_type");
             let data: String = row.get("data");
-            let task_type = match task_type_str.as_str() {
-                "GradientUpdate" => TaskType::GradientUpdate,
-                "ParameterPull" => TaskType::ParameterPull,
-                other => {
-                    error!("Unknown task_type '{}' for task {}", other, task_id);
-                    continue;
-                }
+            let Some(task_type) = task_type_from_str(&task_type_str, &task_id) else {
+                continue;
             };
             tasks.insert(
                 task_id,
@@ -190,6 +242,55 @@ mod tests {
         assert_eq!(recovered.data, "Test data");
 
         // Clean up
+        pool.get()
+            .await
+            .unwrap()
+            .execute("DELETE FROM tasks WHERE task_id = $1", &[&task.task_id])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_task_falls_back_to_database_and_repopulates_cache() {
+        let pool = get_pool().await.expect("pool");
+        let recovery_manager = TaskRecoveryManager::new(pool.clone());
+
+        let task = Task {
+            task_id: Uuid::new_v4(),
+            task_type: TaskType::GradientUpdate,
+            data: "Database-backed task".to_string(),
+        };
+        let task_type = format!("{:?}", task.task_type);
+
+        pool.get()
+            .await
+            .unwrap()
+            .execute(
+                "INSERT INTO tasks (task_id, task_type, data) VALUES ($1,$2,$3)",
+                &[&task.task_id, &task_type, &task.data],
+            )
+            .await
+            .unwrap();
+
+        assert!(!recovery_manager
+            .tasks
+            .read()
+            .await
+            .contains_key(&task.task_id));
+
+        let recovered = recovery_manager
+            .get_task(&task.task_id)
+            .await
+            .unwrap()
+            .expect("task missing");
+        assert_eq!(recovered.task_type, TaskType::GradientUpdate);
+        assert_eq!(recovered.data, task.data);
+        assert!(recovery_manager
+            .tasks
+            .read()
+            .await
+            .contains_key(&task.task_id));
+
         pool.get()
             .await
             .unwrap()


### PR DESCRIPTION
### Motivation
- Ensure single-task lookups use the same deserialization logic as bulk recovery and allow cache-miss fallbacks to the persistent `tasks` table.
- Avoid duplicating `task_type` parsing and keep the in-memory cache synchronized when a task is loaded from the database.

### Description
- Add a helper `task_type_from_str` and reuse it from both `recover_tasks` and the new `TaskRecoveryManager::get_task` to centralize persisted `task_type` deserialization.
- Implement `TaskRecoveryManager::get_task(&Uuid)` which checks the in-memory `tasks` map first and on cache miss queries `tasks` by `task_id`, deserializes `task_type`, repopulates the in-memory cache, and returns the recovered `Task`.
- Update the GET handler to use `TaskRecoveryManager::get_task` instead of reading `task_manager.tasks` directly and return `500` on lookup errors and `404` when not found.
- Add unit tests covering cache-miss database retrieval for both the manager (`test_get_task_falls_back_to_database_and_repopulates_cache`) and the API handler (`test_get_task_from_database_on_cache_miss`).

### Testing
- Ran `rustfmt --edition 2021` and `cargo test --no-run`, both completed successfully.
- Ran the full test suite with `cargo test`, which executed but reported failures in PostgreSQL-backed tests due to `bb8` pool timeouts in this environment; overall result was `16 passed; 7 failed` and the failing tests are related to database pool creation and `task_recovery` DB-dependent scenarios (timeouts).
- The new and existing non-database unit tests executed before the timeout-related failures; failures appear to be environmental (Postgres connection / bb8 pool timeouts) rather than logical regressions in the new lookup implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21b2ef4c832888a45f988da132c7)