### PR TITLE
Include task ID in scheduler error log and ensure scheduler is built

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod signals;
 pub mod load_balancer;
 pub mod task_recovery;
 pub mod error;
+pub mod scheduler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod logging_metrics;
 mod messaging;
 mod node_registry;
 mod principal;
+mod scheduler;
 mod security;
 mod signals;
 mod task_recovery;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -64,7 +64,7 @@ impl Scheduler {
                 })?;
             Ok(())
         } else {
-            error!("No available nodes to schedule task {}");
+            error!("No available nodes to schedule task {}", task.task_id);
             Err(AnKiError::Scheduler("No available nodes".into()))
         }
     }


### PR DESCRIPTION
### Motivation
- Improve observability by including the `task.task_id` in the scheduler error log when no nodes are available. 
- Ensure the `scheduler` module is compiled during library and binary builds so its tests and code are exercised.

### Description
- Updated the `schedule_task` error branch in `src/scheduler.rs` to call `error!("No available nodes to schedule task {}", task.task_id);`.
- Registered the scheduler module in the library by adding `pub mod scheduler;` to `src/lib.rs`.
- Registered the scheduler module in the binary by adding `mod scheduler;` to `src/main.rs` so it is included in the main target.

### Testing
- Ran `cargo test scheduler` and the unit test `scheduler::tests::test_schedule_task` passed.
- Ran the project test suite which included the scheduler tests and they passed (1 test passed for the scheduler target).
- Ran `cargo fmt --check` which reported unrelated formatting diffs in other files (pre-existing), so formatting check did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21adc5ec8328947bdc45d8ea3e0f)