### PR TITLE
Validate model shard counts and guard zero shard_count in AnNode

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -49,6 +49,14 @@ impl AnNodeState {
         channel: Option<&Channel>,
         shard_count: usize,
     ) -> Result<(), Box<dyn Error>> {
+        if shard_count == 0 {
+            return Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "shard_count must be greater than 0",
+            )
+            .into());
+        }
+
         match task.task_type {
             TaskType::GradientUpdate => {
                 let gradient: Vec<f32> = serde_json::from_str(&task.data)?;
@@ -299,6 +307,28 @@ mod tests {
         let err = state.process_task(task, None, 1).await.unwrap_err();
         let err_msg = err.to_string();
         assert!(err_msg.contains("expected 2, received 3"));
+        assert_eq!(state.model_params, original_model);
+        assert_eq!(state.grad_accum, original_accum);
+    }
+
+    #[tokio::test]
+    async fn test_zero_shard_count_fails_without_mutation() {
+        let mut state = AnNodeState {
+            model_params: vec![1.0_f32, 2.0_f32],
+            grad_accum: (vec![0.1_f32, 0.2_f32], 1),
+        };
+        let original_model = state.model_params.clone();
+        let original_accum = state.grad_accum.clone();
+        let task = Task {
+            task_id: Uuid::new_v4(),
+            task_type: TaskType::GradientUpdate,
+            data: serde_json::to_string(&vec![0.3_f32, 0.4_f32]).unwrap(),
+        };
+
+        let err = state.process_task(task, None, 0).await.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("shard_count must be greater than 0"));
         assert_eq!(state.model_params, original_model);
         assert_eq!(state.grad_accum, original_accum);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,21 @@ impl Settings {
         override_from_env_or_file(&mut s, "database_url", "DATABASE_URL")?;
         override_from_env_or_file(&mut s, "otlp_endpoint", "OTLP_ENDPOINT")?;
 
-        s.try_into()
+        Self::from_config(s)
+    }
+
+    fn from_config(s: Config) -> Result<Self, ConfigError> {
+        let settings: Settings = s.try_into()?;
+        settings.validate()
+    }
+
+    fn validate(self) -> Result<Self, ConfigError> {
+        if self.model_shards == 0 {
+            return Err(ConfigError::Message(
+                "model_shards must be greater than 0".into(),
+            ));
+        }
+        Ok(self)
     }
 }
 
@@ -81,5 +95,30 @@ mod tests {
         assert!(settings.otlp_endpoint.is_some());
         assert!(settings.model_shards > 0);
         assert!(settings.training_epochs > 0);
+    }
+
+    #[test]
+    fn test_model_shards_zero_is_invalid() {
+        let mut config = Config::new();
+        config
+            .set("amqp_addr", "amqp://127.0.0.1:5672/%2f")
+            .unwrap();
+        config.set("jwt_secret_key", "test-secret").unwrap();
+        config
+            .set(
+                "database_url",
+                "postgresql://root@localhost:26257/defaultdb?sslmode=disable",
+            )
+            .unwrap();
+        config
+            .set("otlp_endpoint", "http://localhost:4317")
+            .unwrap();
+        config.set("model_shards", 0).unwrap();
+        config.set("training_epochs", 10).unwrap();
+
+        let err = Settings::from_config(config).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("model_shards must be greater than 0"));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent invalid runtime configuration by rejecting `model_shards = 0` as soon as settings are loaded. 
- Defensively avoid mutating node model state when a caller supplies an invalid `shard_count = 0` to `AnNodeState::process_task`.

### Description
- Add `Settings::from_config` and a `validate` method that returns a `ConfigError::Message` when `model_shards == 0`, and make `Settings::new` use `from_config` for post-deserialization validation (`src/config.rs`).
- Add an early check in `AnNodeState::process_task` to return an `InvalidInput` `IoError` if `shard_count == 0` before any state mutation (`src/an_node.rs`).
- Add unit tests `test_model_shards_zero_is_invalid` (config validation) and `test_zero_shard_count_fails_without_mutation` (process_task defensive behavior) to ensure errors are returned and internal state is not modified (`src/config.rs`, `src/an_node.rs`).

### Testing
- Ran formatter check with `rustfmt --edition 2021 --check src/config.rs src/an_node.rs` which succeeded.
- Ran the new unit tests with `cargo test test_model_shards_zero_is_invalid` and `cargo test test_zero_shard_count_fails_without_mutation`, and both tests passed.
- Attempted full `cargo test`; relevant unit tests for these changes passed, but unrelated database-backed tests failed in this environment with `bb8` pool timeouts (`TimedOut`), so the full suite did not complete successfully here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21b6732c8328ba52b25fc386f1ad)