### PR TITLE
Fix persistent task deletion cache misses

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 // api.rs: Implements REST API endpoints for interacting with the task recovery system.
 
-use crate::common::{Task, TaskType};
+use crate::common::Task;
 use crate::task_recovery::TaskRecoveryManager;
 use std::sync::Arc;
 use tracing::error;
@@ -111,6 +111,7 @@ async fn delete_task_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::TaskType;
     use crate::database::get_pool;
     use warp::test::request;
 
@@ -161,7 +162,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_task() {
         let pool = get_pool().await.expect("pool");
-        let task_manager = Arc::new(TaskRecoveryManager::new(pool));
+        let task_manager = Arc::new(TaskRecoveryManager::new(pool.clone()));
         let api = Api::new(task_manager.clone());
 
         let task = Task {
@@ -184,5 +185,50 @@ mod tests {
             .reply(&api.filters())
             .await;
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+        let database_only_task = Task {
+            task_id: Uuid::new_v4(),
+            task_type: TaskType::GradientUpdate,
+            data: "Database-only task data".to_string(),
+        };
+        let task_type = format!("{:?}", database_only_task.task_type);
+        pool.get()
+            .await
+            .unwrap()
+            .execute(
+                "INSERT INTO tasks (task_id, task_type, data) VALUES ($1, $2, $3)",
+                &[
+                    &database_only_task.task_id,
+                    &task_type,
+                    &database_only_task.data,
+                ],
+            )
+            .await
+            .unwrap();
+        assert!(!task_manager
+            .tasks
+            .read()
+            .await
+            .contains_key(&database_only_task.task_id));
+
+        let res = request()
+            .method("DELETE")
+            .path(&format!("/tasks/{}", database_only_task.task_id))
+            .reply(&api.filters())
+            .await;
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let remaining_rows = pool
+            .get()
+            .await
+            .unwrap()
+            .query_one(
+                "SELECT COUNT(*) FROM tasks WHERE task_id = $1",
+                &[&database_only_task.task_id],
+            )
+            .await
+            .unwrap();
+        let remaining_count: i64 = remaining_rows.get(0);
+        assert_eq!(remaining_count, 0);
     }
 }

--- a/src/task_recovery.rs
+++ b/src/task_recovery.rs
@@ -85,36 +85,44 @@ ON CONFLICT (task_id) DO UPDATE SET task_type=$2, data=$3",
             tasks.remove(task_id)
         };
 
-        let task = match removed_task {
-            Some(task) => task,
-            None => {
-                debug!("Task not found for removal: {}", task_id);
-                return Ok(false);
-            }
-        };
+        if removed_task.is_some() {
+            info!("Removed task from recovery manager: {}", task_id);
+        } else {
+            debug!("Task not found in recovery manager cache: {}", task_id);
+        }
 
-        info!("Removed task from recovery manager: {}", task_id);
         let conn = match self.pool.get().await {
             Ok(conn) => conn,
             Err(e) => {
                 error!("Failed to acquire connection: {:?}", e);
-                let mut tasks = self.tasks.write().await;
-                tasks.insert(task.task_id, task.clone());
+                if let Some(task) = removed_task.as_ref() {
+                    let mut tasks = self.tasks.write().await;
+                    tasks.insert(task.task_id, task.clone());
+                }
                 return Err(AnKiError::TaskRecovery(e.to_string()));
             }
         };
 
-        if let Err(e) = conn
+        let deleted_rows = match conn
             .execute("DELETE FROM tasks WHERE task_id = $1", &[task_id])
             .await
         {
-            error!("Failed to remove task from database: {:?}", e);
-            let mut tasks = self.tasks.write().await;
-            tasks.insert(task.task_id, task);
-            return Err(AnKiError::TaskRecovery(e.to_string()));
+            Ok(count) => count,
+            Err(e) => {
+                error!("Failed to remove task from database: {:?}", e);
+                if let Some(task) = removed_task.as_ref() {
+                    let mut tasks = self.tasks.write().await;
+                    tasks.insert(task.task_id, task.clone());
+                }
+                return Err(AnKiError::TaskRecovery(e.to_string()));
+            }
+        };
+
+        if deleted_rows > 0 {
+            debug!("Removed persistent task from database: {}", task_id);
         }
 
-        Ok(true)
+        Ok(removed_task.is_some() || deleted_rows > 0)
     }
 
     pub async fn recover_tasks(&self) -> Result<(), AnKiError> {


### PR DESCRIPTION
### Motivation

- Ensure persistent tasks are removed even when the in-memory cache does not contain the task, and avoid reporting "not found" incorrectly for database-only tasks.

### Description

- Update `TaskRecoveryManager::remove_task` to always attempt the database `DELETE` even when `tasks.remove(task_id)` returns `None`, and use the SQL affected-row count to determine whether a persistent row was removed.
- Return `Ok(true)` when the database deleted a row even if the in-memory cache missed, and preserve the previous rollback behavior only when a cached task was removed and the DB operation fails (re-insert the cached task on DB connection/error).
- Small refactors to avoid moving the removed task (use `removed_task.as_ref()` and `clone()` where necessary).
- Extend `delete_task_handler` tests in `src/api.rs` to cover deleting a task that exists only in the database and assert the DB row is removed.

### Testing

- Ran `git diff --check` which succeeded.
- Ran `cargo check` which succeeded.
- Ran `cargo test --no-run` which succeeded (built tests without running them).
- Ran `cargo test test_delete_task -- --test-threads=1` which exercised the updated API test but failed in this environment because `get_pool()` timed out acquiring a database pool connection (test infrastructure issue, not logic regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe21b2f01c832893e3b67ede83d557)