### PR TITLE
Repair the build after the stacked merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A distributed neural network project that supports task scheduling, load balanci
 - **Fault Tolerance:** Tasks are persisted to the database by the task recovery manager, so they survive a node restart and can be recovered by ID.
 - **Secure Communication:** JWT-based authentication and role-based access control on the REST API, plus AES-256-GCM encryption of model-update messages exchanged between nodes (keyed by `jwt_secret_key`).
 - **Dynamic Node Discovery:** The principal derives a live cluster view from node heartbeats — nodes join by heartbeating and are evicted after `NODE_TTL_MS` of silence. No separate registration step is required.
-- **Consensus & Leader Election:** Uses the Raft protocol (via [`openraft`](https://github.com/datafuselabs/openraft)) for a replicated, consistent log and automatic leader election. The principal runs a Raft node — a single-member cluster today, with multi-node operation arriving once the networking transport in `raft_node` is implemented.
+- **Consensus & Leader Election:** Uses the Raft protocol (via [`openraft`](https://github.com/datafuselabs/openraft)) for a replicated, consistent log and automatic leader election, over a durable [`sled`](https://github.com/spacejam/sled)-backed log that survives restarts. Principals replicate to each other over HTTP, so a multi-principal cluster tolerates the loss of a minority of its members.
 - **Monitoring and Metrics:** Supports Prometheus metrics and detailed logging for monitoring.
 - **Configurable:** Easily configurable using environment variables and configuration files.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@ pub mod api;
 pub mod common;
 pub mod config;
 pub mod database;
-pub mod election;
 pub mod error;
 pub mod health;
 pub mod ki_node;

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -4,7 +4,9 @@ use crate::common::NodeRole;
 use crate::health;
 use crate::messaging::{consume_messages, declare_queue};
 use crate::node_registry::{self, NodeRegistry};
-use crate::raft_node;
+use crate::raft_network;
+use crate::raft_node::{self, AnKiRaft};
+use crate::raft_store::ClusterRequest;
 use crate::signals;
 
 use crate::config::load_settings;
@@ -275,7 +277,28 @@ async fn log_cluster_view(registry: &NodeRegistry) {
     );
 }
 
-async fn process_update_request(update: UpdateRequest) -> Result<(), Box<dyn Error>> {
+/// What the principal decided to do with an update request, which determines
+/// how the delivery is settled.
+#[derive(Debug, PartialEq, Eq)]
+enum UpdateOutcome {
+    /// Committed through Raft. Acknowledge the delivery.
+    Applied,
+    /// The request itself is bad and will never succeed. Dead-letter it rather
+    /// than requeueing a message that can only fail again.
+    Rejected(String),
+    /// The request is well-formed but this node cannot serve it right now,
+    /// typically because it is not the Raft leader. Requeue so another
+    /// principal — or this one, once it catches up — can take it.
+    Retry(String),
+}
+
+/// Applies an update request by committing it to the Raft log.
+///
+/// Every accepted request becomes a [`ClusterRequest`], so the decision is
+/// replicated to every principal instead of living in this process's memory.
+/// Only the leader may write, which is why a follower answers [`UpdateOutcome::Retry`]
+/// rather than applying anything locally.
+async fn process_update_request(update: UpdateRequest, raft: Option<&AnKiRaft>) -> UpdateOutcome {
     info!("Processing update request with ID: {}", update.update_id);
 
     let request = match to_cluster_request(update.content) {


### PR DESCRIPTION
**`main` does not currently compile.** This restores it. Recommend merging before anything else.

```
error[E0583]: file not found for module `election`
 --> src/lib.rs:6:1
```

## What happened

This is a conflict git cannot resolve correctly on its own, not a mistake in any individual PR.

Two branches edited **adjacent lines** of `src/lib.rs`. #136 removed `pub mod election;` (and deleted `election.rs`); #137 removed `pub mod dht;` (and deleted `dht.rs`). Git presents that as one conflicting hunk:

```
<<<<<<< HEAD
pub mod dht;
=======
pub mod election;
>>>>>>> claude/consolidate-node-discovery
```

The correct resolution — drop **both** lines — looks like *neither side*. Picking either one leaves a `pub mod` with no file behind it. I reproduced this exactly by replaying the merges locally.

The same shape hit `src/principal.rs`, where #137 added the node-registry wiring and #140 replaced update handling with Raft writes. Resolving to one side kept #140's function *bodies* while dropping its signatures — so `UpdateOutcome`, the two-argument `process_update_request`, and the `raft_network` / `AnKiRaft` / `ClusterRequest` imports all vanished while their call sites remained.

## The fix

Both conflicts are purely additive on each side, so both resolve as **unions** — the registry wiring and the Raft update handling both belong in the merged result. Concretely:

- `src/lib.rs`: drop `election` *and* `dht`.
- `src/principal.rs`: keep `log_cluster_view` (#137) *and* `UpdateOutcome` + the Raft-backed `process_update_request` (#140), plus the union of both import sets.
- `README.md`: the consensus bullet still promised multi-node operation "once the networking transport in `raft_node` is implemented" — that shipped in #139, in the same batch of merges.

## How I verified it

Rather than trusting a hand-patch to be complete, I reconstructed the merge **independently**: branched from the pre-stack commit (`16c8cac`), merged all five branch heads in order, and resolved each conflict from scratch without reference to the repair.

That tree and this one are **byte-identical outside `Cargo.lock`**, and both:
- build clean (`cargo check --all-targets`)
- pass `cargo clippy --all-targets -- -D warnings`
- pass `cargo fmt --check`
- pass **124/124 tests**

I also enumerated the test names on the repaired tree and confirmed every test from all five PRs survived — including `node_registry::*` and `health::*` from #137 and `raft_network::two_nodes_elect_a_leader_and_replicate_over_http` from #139. A tree that merely compiles is not evidence that a bad merge kept everything, so this was worth checking separately.

## Related gap, handled separately

PR #140 targeted another branch rather than `main`, and the workflows are `on: pull_request: branches: [main]` — so it received **no CI at all**. I'll send that as its own PR so this one can merge immediately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_