### PR TITLE
Run CI on every pull request, not just those targeting main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,9 @@ name: Deploy Checks
 on:
   push:
     branches: [ "main" ]
+  # No branch filter: `branches` matches the PR's base, so `[main]` skipped
+  # every stacked pull request.
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   helm:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [ "main" ]
+  # No branch filter: a `branches` list here matches the PR's *base*, so
+  # `[main]` silently skipped every stacked pull request. Those are exactly the
+  # ones most likely to merge badly, so they need CI most.
   pull_request:
-    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -17,15 +19,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy,rustfmt
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}      
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      # `--all-targets` so tests and benches are linted too; without it clippy
+      # only sees the library and binaries.
       - name: Lint
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
       - name: Format
         run: cargo fmt --check
       - name: Test


### PR DESCRIPTION
First of four PRs toward v0.1.0. **Merge order matters** — see the note at the bottom.

## The gap

Both workflows were:

```yaml
on:
  pull_request:
    branches: [ "main" ]
```

That filter matches the pull request's **base** branch. Any PR opened against another branch got no checks at all — #140 merged with **zero** CI runs.

That is backwards: stacked PRs are the ones most likely to merge badly, as the broken `main` in #141 demonstrated. They need CI most, and were the only ones not getting it.

Dropping the filter makes both workflows fire on every PR regardless of base. `push` stays limited to `main` so branch pushes don't duplicate the PR run.

## Two related gaps in the same file

- **`cargo clippy -- -D warnings` only lints the library and binaries.** Test code was never linted in CI, even though it's the bulk of recent additions — a clippy failure in a test would pass CI and fail for anyone running `--all-targets` locally. Now `--all-targets`, matching what contributors actually run.
- **`actions/cache@v3` runs on deprecated Node 20** and warns on every run. Bumped to v4.

## Verification

Parsed both workflow files and asserted `pull_request` carries no branch filter, and ran `cargo clippy --all-targets -- -D warnings` locally — clean, so the stricter step won't fail on merge.

I deliberately did **not** add RabbitMQ/Postgres service containers to run the `integration-tests` feature, even though those tests have never executed. No Docker in my environment means I couldn't verify such a job actually passes, and an unverified CI job is worse than none. Worth doing as its own change by someone who can run it.

## Merge order for the v0.1.0 stack

After the #141 collision I've made the remaining work a **linear stack** — each PR based on the previous — so merging in order is conflict-free:

1. **this PR** → `main`
2. wire the scheduler → this branch
3. metrics report reality → previous
4. release engineering (CHANGELOG, release workflow, version sync) → previous

Merging them in order requires no conflict resolution. Merging out of order will reproduce the adjacent-line problem from #141.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_