### PR TITLE
Report real task throughput and real Raft leadership

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A distributed neural network project that supports task scheduling, load balanci
 - **Secure Communication:** JWT-based authentication and role-based access control on the REST API, plus AES-256-GCM encryption of model-update messages exchanged between nodes (keyed by `jwt_secret_key`).
 - **Dynamic Node Discovery:** The principal derives a live cluster view from node heartbeats — nodes join by heartbeating and are evicted after `NODE_TTL_MS` of silence. No separate registration step is required.
 - **Consensus & Leader Election:** Uses the Raft protocol (via [`openraft`](https://github.com/datafuselabs/openraft)) for a replicated, consistent log and automatic leader election, over a durable [`sled`](https://github.com/spacejam/sled)-backed log that survives restarts. Principals replicate to each other over HTTP, so a multi-principal cluster tolerates the loss of a minority of its members.
-- **Monitoring and Metrics:** Supports Prometheus metrics and detailed logging for monitoring.
+- **Monitoring and Metrics:** Prometheus metrics for task throughput and latency, plus a `consensus_state` gauge driven by real Raft leadership, and OpenTelemetry tracing.
 - **Configurable:** Easily configurable using environment variables and configuration files.
 
 ### Task Recovery Consistency
@@ -406,8 +406,19 @@ The collector scrapes these metrics and re-exports them on `9464` for federation
 
 Import the sample dashboard found at `config/grafana/node_overview.json` into Grafana. It visualizes:
 
-- **Node Status:** current health of each node.
-- **Consensus State:** leader or follower role.
-- **Task Throughput:** rate of tasks processed per minute.
+| Panel | Metric | Reported by |
+| --- | --- | --- |
+| Node Status | `node_status` | every node, set at startup |
+| Consensus State | `consensus_state` | principals only — `1` on the Raft leader, `0` on followers |
+| Task Throughput | `rate(tasks_processed_total[1m])` | An and Ki nodes, on each successfully processed task |
+
+`consensus_state` is published only by principals, because An and Ki nodes are
+not Raft members and have no leadership to report. It tracks openraft's
+leadership watch, so it changes as elections happen rather than being assumed
+from how a process was started.
+
+Only successful tasks increment `tasks_processed_total`; a task that failed was
+not processed, and counting it would make throughput look healthy during an
+outage.
 
 Configure Grafana to use the collector's Prometheus exporter (`http://localhost:9464`) as a data source.

--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -7,7 +7,7 @@ use crate::{
     api,
     common::{self, Task, TaskType},
     config::load_settings,
-    health, messaging, scheduler, security, signals,
+    health, logging_metrics, messaging, scheduler, security, signals,
 };
 use futures_util::stream::StreamExt;
 use lapin::{
@@ -15,6 +15,7 @@ use lapin::{
     Channel,
 };
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::{watch, Mutex};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -345,11 +346,15 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                             match serde_json::from_slice::<Task>(&delivery.data) {
                                 Ok(task_message) => {
                                     info!("Received task: {:?}", task_message);
+                                    let started_at = Instant::now();
                                     let outcome = state
                                         .lock()
                                         .await
                                         .process_task(task_message, Some(&channel), shard_count)
                                         .await;
+                                    if outcome.is_ok() {
+                                        logging_metrics::record_task_processed(started_at);
+                                    }
                                     match outcome {
                                         Ok(()) => {
                                             match processing_disposition(ProcessingOutcome::Succeeded) {

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -4,6 +4,7 @@
 use crate::common::{self, Task, TaskType};
 use crate::config::load_settings;
 use crate::health;
+use crate::logging_metrics;
 use crate::messaging;
 use crate::security;
 use crate::signals;
@@ -14,6 +15,7 @@ use lapin::{
 };
 use std::error::Error;
 use std::io::{Error as IoError, ErrorKind};
+use std::time::Instant;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -322,8 +324,13 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 }
 
 async fn process_and_send_task(task: Task, channel: &Channel) -> Result<(), Box<dyn Error>> {
+    let started_at = Instant::now();
     let result = perform_computation(task).await?;
-    send_result(result, channel).await
+    send_result(result, channel).await?;
+    // Only successful tasks are counted: a task that failed was not processed,
+    // and counting it would inflate the throughput panel during an outage.
+    logging_metrics::record_task_processed(started_at);
+    Ok(())
 }
 
 pub async fn perform_computation(task: Task) -> Result<Task, Box<dyn Error>> {

--- a/src/logging_metrics.rs
+++ b/src/logging_metrics.rs
@@ -84,11 +84,30 @@ pub fn set_consensus_state(state: f64) {
     CONSENSUS_STATE.set(state);
 }
 
-pub fn log_task_processing(start_time: Instant) {
-    let elapsed = start_time.elapsed();
+/// Records that one task finished, feeding both `tasks_processed_total` and
+/// the `task_processing_seconds` histogram.
+///
+/// Call this on every completed task on every node type: the Grafana dashboard
+/// charts `rate(tasks_processed_total[1m])` as cluster-wide throughput, so a
+/// node that processes tasks without recording them makes the panel understate
+/// the cluster rather than merely omitting one series.
+pub fn record_task_processed(started_at: Instant) {
+    let elapsed = started_at.elapsed();
     PROCESSING_TIME.observe(elapsed.as_secs_f64());
     TASKS_PROCESSED.inc();
-    debug!("Task processed in {:?} seconds.", elapsed);
+    debug!("Task processed in {:?}.", elapsed);
+}
+
+/// Current value of `tasks_processed_total`, for assertions in tests.
+#[cfg(test)]
+pub fn tasks_processed_total() -> f64 {
+    TASKS_PROCESSED.get()
+}
+
+/// Current value of `consensus_state`, for assertions in tests.
+#[cfg(test)]
+pub fn consensus_state() -> f64 {
+    CONSENSUS_STATE.get()
 }
 
 pub async fn metrics_endpoint() -> Result<impl warp::Reply, Infallible> {
@@ -132,8 +151,15 @@ mod tests {
     }
 
     #[test]
-    fn test_log_task_processing() {
-        let start_time = Instant::now() - Duration::from_millis(50);
-        log_task_processing(start_time);
+    fn recording_a_task_advances_the_throughput_counter() {
+        // The Grafana dashboard charts `rate(tasks_processed_total[1m])`, so a
+        // counter that never moves renders as a permanently flat line. The
+        // counter is process-wide, so assert on the delta rather than an
+        // absolute value.
+        let before = tasks_processed_total();
+
+        record_task_processed(Instant::now() - Duration::from_millis(50));
+
+        assert_eq!(tasks_processed_total(), before + 1.0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,21 +23,20 @@ async fn main() {
 
     match node_type.as_str() {
         "principal" => {
-            logging_metrics::set_consensus_state(1.0);
+            // consensus_state is reported by the principal's Raft node itself,
+            // from real leadership, rather than assumed from the CLI argument.
             if let Err(e) = principal::run().await {
                 error!("Failed to run principal node: {:?}", e);
                 std::process::exit(1);
             }
         }
         "an" => {
-            logging_metrics::set_consensus_state(0.0);
             if let Err(e) = an_node::run().await {
                 error!("Failed to run an node: {:?}", e);
                 std::process::exit(1);
             }
         }
         "ki" => {
-            logging_metrics::set_consensus_state(0.0);
             if let Err(e) = ki_node::run().await {
                 error!("Failed to run ki node: {:?}", e);
                 std::process::exit(1);

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -164,6 +164,9 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                 ),
             }
 
+            // Report real leadership on the `consensus_state` gauge.
+            raft_node::spawn_leadership_reporter(&node, raft_cancel.clone());
+
             Some(node)
         }
         Err(e) => {

--- a/src/raft_node.rs
+++ b/src/raft_node.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use openraft::{BasicNode, Config, Raft};
+use tokio_util::sync::CancellationToken;
 
 use crate::raft_network::{self, HttpNetworkFactory};
 use crate::raft_store::{NodeId, SledStore, TypeConfig};
@@ -117,6 +118,56 @@ pub async fn start_cluster(
     }
 
     Ok(node)
+}
+
+/// The `consensus_state` gauge value for a node: 1.0 when it is the leader,
+/// 0.0 otherwise.
+///
+/// Leadership is decided by comparing the cluster's current leader against this
+/// node's own id. A node that merely *has* a leader is a follower, so the two
+/// cases must not be conflated — reporting 1.0 for "a leader exists" would show
+/// every member of a healthy cluster as leader simultaneously.
+pub fn leadership_gauge(current_leader: Option<NodeId>, node_id: NodeId) -> f64 {
+    if current_leader == Some(node_id) {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+/// Keeps the `consensus_state` gauge in step with this node's Raft leadership
+/// until `cancel` fires.
+///
+/// openraft publishes metrics on a watch channel, so this reacts to leadership
+/// changes as they happen rather than polling.
+pub fn spawn_leadership_reporter(node: &RaftNode, cancel: CancellationToken) {
+    let mut metrics = node.raft.metrics();
+    let node_id = node.node_id;
+
+    tokio::spawn(async move {
+        // Publish the starting value so the gauge is correct before the first
+        // leadership change, not just after it.
+        crate::logging_metrics::set_consensus_state(leadership_gauge(
+            metrics.borrow().current_leader,
+            node_id,
+        ));
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                changed = metrics.changed() => {
+                    if changed.is_err() {
+                        // The Raft node shut down; stop reporting.
+                        break;
+                    }
+                    let leader = metrics.borrow().current_leader;
+                    crate::logging_metrics::set_consensus_state(
+                        leadership_gauge(leader, node_id),
+                    );
+                }
+            }
+        }
+    });
 }
 
 /// Resolves this node's numeric Raft id from `RAFT_NODE_ID`, defaulting to 1.
@@ -303,6 +354,48 @@ mod tests {
         let voters: Vec<u64> = metrics.membership_config.membership().voter_ids().collect();
         assert_eq!(voters, vec![1, 2]);
 
+        node.shutdown().await.expect("clean shutdown");
+    }
+
+    #[test]
+    fn only_the_leader_reports_consensus_state_one() {
+        assert_eq!(leadership_gauge(Some(1), 1), 1.0, "leader");
+        assert_eq!(
+            leadership_gauge(Some(2), 1),
+            0.0,
+            "a follower in a healthy cluster must not report itself leader"
+        );
+        assert_eq!(leadership_gauge(None, 1), 0.0, "no leader elected yet");
+    }
+
+    #[tokio::test]
+    async fn the_gauge_follows_real_leadership() {
+        let store = SledStore::temporary().expect("temporary store");
+        let node = start_single_node(1, store).await.expect("start raft");
+        let cancel = CancellationToken::new();
+        spawn_leadership_reporter(&node, cancel.clone());
+
+        node.raft
+            .wait(Some(Duration::from_secs(10)))
+            .state(openraft::ServerState::Leader, "leader")
+            .await
+            .expect("became leader");
+
+        // The reporter reacts to a watch notification, so give it a moment to
+        // observe the election rather than asserting on a race.
+        for _ in 0..50 {
+            if crate::logging_metrics::consensus_state() == 1.0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(
+            crate::logging_metrics::consensus_state(),
+            1.0,
+            "a node that won an election must report itself leader"
+        );
+
+        cancel.cancel();
         node.shutdown().await.expect("clean shutdown");
     }
 


### PR DESCRIPTION
> **Stacked on #143.** Merge that first. (3 of 4 toward v0.1.0.)

Both metrics on the Grafana dashboard were fiction. For a release that ships a dashboard, that seemed worth fixing before tagging.

## `tasks_processed_total` was always zero

`log_task_processing` existed and was **never called from anywhere**. So `tasks_processed_total` and `task_processing_seconds` sat at zero for the life of every process, while `config/grafana/node_overview.json` charted `rate(tasks_processed_total[1m])` as its "Task Throughput" panel — a permanently flat line, by construction.

An and Ki nodes now record every task they finish. **Only successful tasks count:** a task that failed was not processed, and counting failures would make throughput look healthy precisely during an outage.

## `consensus_state` described the command line, not the cluster

It was set once in `main` from the CLI argument:

```rust
"principal" => { set_consensus_state(1.0); ... }   // leader, forever
"an"        => { set_consensus_state(0.0); ... }   // "follower" — not a Raft member at all
"ki"        => { set_consensus_state(0.0); ... }
```

A principal that lost an election still reported `1`. An and Ki nodes reported a leadership state they have no way to hold.

Now only principals publish it, driven by openraft's leadership watch channel, so it reacts to elections as they happen. Two details worth review:

- **Leadership is `current_leader == self`, not `current_leader.is_some()`.** Conflating them would show every member of a healthy cluster as leader simultaneously. `leadership_gauge` is a separate pure function so this is pinned by a test.
- The reporter publishes the starting value before waiting on the watch, so the gauge is correct from process start rather than only after the first leadership *change*.

An and Ki no longer publish the gauge at all — the metric is lazily registered, so it simply doesn't appear in their scrape. That's the honest representation: they aren't Raft members.

## The old test would have passed either way

```rust
#[test]
fn test_log_task_processing() {
    let start_time = Instant::now() - Duration::from_millis(50);
    log_task_processing(start_time);   // asserts nothing
}
```

It passed just as happily with the function wired to nothing. It now asserts the counter actually advances (on the delta, since the counter is process-wide). And `the_gauge_follows_real_leadership` drives a real single-node Raft cluster through an election and asserts the gauge follows.

## Also

`log_task_processing` → `record_task_processed`, which is what it does — it feeds a counter and a histogram; it doesn't log.

README now documents which node type reports which metric, since "principals only" is not obvious from the dashboard.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 119 → 121.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_