### PR TITLE
Prepare the v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+# Tag-driven: pushing `v0.1.0` builds and publishes the release for it.
+on:
+  push:
+    tags: [ "v*" ]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      # A tag that disagrees with Cargo.toml would publish artifacts whose
+      # embedded version does not match the release they are attached to.
+      # Catch that before building rather than after publishing.
+      - name: Check the tag matches the crate version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          crate="$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          chart="$(python3 -c 'import re;print(re.search(r"^version:\s*(\S+)", open("helm/an-ki/Chart.yaml").read(), re.M).group(1))')"
+          echo "tag=$tag crate=$crate chart=$chart"
+          if [ "$tag" != "$crate" ]; then
+            echo "::error::tag v$tag does not match Cargo.toml version $crate"; exit 1
+          fi
+          if [ "$tag" != "$chart" ]; then
+            echo "::error::tag v$tag does not match Helm chart version $chart"; exit 1
+          fi
+
+      - name: Verify the release build
+        run: |
+          cargo fmt --check
+          cargo clippy --all-targets -- -D warnings
+          cargo test
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Package
+        run: |
+          version="${GITHUB_REF_NAME}"
+          target="an-ki-${version}-x86_64-unknown-linux-gnu"
+          mkdir -p "dist/${target}"
+          cp target/release/distributed_neural_network "dist/${target}/an-ki"
+          cp README.md LICENSE CHANGELOG.md "dist/${target}/"
+          # Ship only the example config. `config/default.toml` carries a
+          # placeholder `jwt_secret_key`, and a downloadable artifact containing
+          # a ready-to-run secret invites someone to deploy with it.
+          mkdir -p "dist/${target}/config"
+          cp config/default.example "dist/${target}/config/"
+          tar -czf "dist/${target}.tar.gz" -C dist "${target}"
+          (cd dist && sha256sum "${target}.tar.gz" > "${target}.tar.gz.sha256")
+
+      # helm is not guaranteed on the runner image, and deploy.yml already
+      # installs it explicitly rather than assuming it.
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Package Helm chart
+        run: helm package helm/an-ki --destination dist
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.sha256
+            dist/*.tgz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-08-14
+
+First tagged release. The system runs a complete training round across
+principal, An, and Ki nodes, with consensus, discovery, and health monitoring
+backed by working implementations rather than placeholders.
+
+### Added
+
+- **Training rounds that complete.** An nodes dispatch one task per model shard
+  each epoch onto `ki_task_queue`; Ki nodes compute and reply on
+  `an_task_queue`; the An node averages a full set of gradients and broadcasts
+  the updated model on `ki_model_queue`. Configured by `model_shards`,
+  `model_dimension`, `training_epochs`, and `epoch_interval_ms`.
+- **Durable Raft consensus.** A `sled`-backed store holds the log, vote, and
+  state machine, flushing the writes Raft cannot afford to lose before each call
+  returns. A restarted principal resumes its cluster instead of re-initializing
+  as a new one.
+- **Multi-principal clusters.** Principals exchange Raft RPCs over HTTP
+  (`/raft/append-entries`, `/raft/vote`, `/raft/install-snapshot`), with
+  membership described by `RAFT_PEERS`. A cluster now tolerates the loss of a
+  minority of its principals.
+- **Replicated cluster state.** Role assignments and configuration overrides are
+  `ClusterRequest` entries in the Raft log, requested over
+  `principal_update_queue` and readable from any principal.
+- **Heartbeat-derived node discovery.** The principal maintains a live
+  `NodeRegistry` from heartbeats, evicting nodes silent for `NODE_TTL_MS` and
+  logging cluster composition every `CLUSTER_REPORT_INTERVAL_MS`.
+- **REST task API** on An nodes, authenticated with JWTs and role-checked, over
+  a database-backed task recovery manager.
+- **Deployment**: Helm chart running the principal as a `StatefulSet` with
+  per-replica persistent volumes and ordinal-derived Raft node ids, plus a
+  headless service for peer DNS.
+
+### Changed
+
+- `consensus_state` is published only by principals and driven by real Raft
+  leadership, rather than being assumed from the command-line argument.
+- `tasks_processed_total` and `task_processing_seconds` are now recorded on every
+  successfully processed task, so the Grafana throughput panel reflects the
+  cluster.
+- Heartbeats carry the sender's role, letting the principal build a complete
+  cluster view without a registration handshake.
+- `NodeInfo::id` is a string, matching the identity `NODE_ID` actually carries.
+- CI runs on every pull request regardless of base branch, and lints
+  `--all-targets`.
+
+### Removed
+
+- `election`, superseded by openraft. Its `run_leader_election` never counted
+  votes.
+- `backup`, superseded by the database-backed task recovery manager.
+- `validation`, unreferenced, and its message check rejected every JSON payload
+  the nodes exchange.
+- `dht`, an in-process `HashMap` that could not perform discovery; replaced by
+  the heartbeat-derived registry.
+- `load_balancer`, which selected a node id nothing could route to. Every Ki node
+  consumes from the same queue, so the broker performs the distribution.
+- The `database` cluster-update variant, which would have executed arbitrary SQL
+  submitted by anyone able to publish to the queue.
+
+### Known limitations
+
+- The per-shard computation is a placeholder: `perform_computation` returns twice
+  its input rather than a real gradient. This release provides the distributed
+  round trip, not a training algorithm.
+- Tests behind the `integration-tests` feature, which exercise the live RabbitMQ
+  and PostgreSQL paths, are not run in CI.
+- The message-encryption key is derived from `jwt_secret_key`, so one secret
+  covers both authentication and message confidentiality.
+
+[Unreleased]: https://github.com/seanwevans/an-ki/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/seanwevans/an-ki/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+Thanks for your interest in the project. This document covers the workflow and
+the checks a change needs to pass.
+
+## Getting set up
+
+See [Getting Started](README.md#getting-started) in the README for prerequisites
+(Rust, RabbitMQ, CockroachDB/PostgreSQL) and configuration.
+
+Install the pre-commit hooks so formatting and lints run before each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+## Checks
+
+CI runs these on every pull request, whatever branch it targets. Run them
+locally first — they are the same commands:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Note `--all-targets`: without it clippy skips test code.
+
+Tests requiring a live broker or database are behind a feature flag and do not
+run by default or in CI:
+
+```bash
+cargo test --features integration-tests
+```
+
+Chart changes are validated by the Deploy Checks workflow, which runs
+`helm lint` and renders the templates against every values file.
+
+## Pull requests
+
+- **One concern per pull request.** Small, focused changes are easier to review
+  and far easier to merge.
+- **Explain the reasoning, not just the diff.** Why this approach, what was
+  rejected, and what a reviewer should look at hardest.
+- **Say what you verified and what you did not.** An untested path is fine as
+  long as it is called out; an untested path described as tested is not.
+
+### Stacked pull requests
+
+When a change depends on another, base it on that branch and say so in the
+description. **Merge stacked pull requests in order.**
+
+This matters more than it sounds. Merging out of order once produced a `main`
+that did not compile: two branches removed adjacent lines from `src/lib.rs`, git
+offered the conflict as a choice between the two, and the correct resolution —
+dropping *both* lines — looked like neither side. Keeping the stack linear and
+merging bottom-up avoids the whole class of problem.
+
+## Commit messages
+
+Explain what changed and why. If a change fixes something subtle, say what the
+old behaviour was — the next reader will not have your context.
+
+## Security
+
+Please do not open public issues for security problems. See
+[SECURITY.md](SECURITY.md) for how to report them.
+
+## License
+
+By contributing you agree that your contributions are licensed under the MIT
+License, the same as the rest of the project.

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ PostgreSQL URL:
 export DATABASE_URL="postgresql://root@localhost:26257/defaultdb?sslmode=disable"
 ```
 
+### Configuration
+
 4. **Configure the project:**
    Create a `config/` directory and add configuration files. Start by copying the provided example configuration:
    ```bash
@@ -367,6 +369,32 @@ and the principal learns cluster membership from heartbeats (see
 [Health Monitoring and Node Discovery](#health-monitoring-and-node-discovery)),
 so only `amqp_addr` needs to be configured.
 
+## Modules Overview
+
+| Module | Responsibility |
+| --- | --- |
+| `main` | Entry point; dispatches to a node type by CLI argument |
+| `principal` | Coordinator: consumes cluster update requests and commits them through Raft |
+| `an_node` | Dispatches training rounds, aggregates gradients, broadcasts the model, serves the task API |
+| `ki_node` | Executes tasks and returns results |
+| `scheduler` | Builds and publishes each epoch's tasks |
+| `raft_store` | Replicated cluster state and its durable `sled`-backed Raft storage |
+| `raft_node` | Assembles the Raft instance; cluster bootstrap and leadership reporting |
+| `raft_network` | HTTP transport carrying Raft RPCs between principals |
+| `node_registry` | Live cluster membership derived from heartbeats |
+| `health` | Heartbeat publishing and the principal's health monitor |
+| `messaging` | RabbitMQ connection, publish, consume, and encrypted payload helpers |
+| `api` | REST task endpoints with JWT authentication and role checks |
+| `task_recovery` | Task persistence and recovery against PostgreSQL |
+| `database` | Connection pool and migrations |
+| `security` | JWT issuance and verification, AES-256-GCM messages, certificate handling |
+| `network` | TLS connection management between nodes |
+| `logging_metrics` | Tracing setup, Prometheus metrics, and the metrics endpoint |
+| `config` | Settings loading from files and environment |
+| `common` | Shared task and node types |
+| `error` | Crate-wide error type |
+| `signals` | Shutdown signal handling |
+
 ## Development
 
 ### Pre-commit Hooks
@@ -382,6 +410,34 @@ Run all checks manually with:
 
 ```bash
 pre-commit run --all-files
+```
+
+### Testing
+
+```bash
+cargo test
+```
+
+Tests that need a live RabbitMQ or PostgreSQL are behind a feature flag and are
+excluded from the default run:
+
+```bash
+cargo test --features integration-tests
+```
+
+These are not currently run in CI; they need a broker and a database available.
+
+### Building
+
+```bash
+cargo build --release
+```
+
+The optional `tch` feature swaps the placeholder computation for tensor
+operations via libtorch, which must be installed separately:
+
+```bash
+cargo build --release --features tch
 ```
 
 ## Monitoring
@@ -422,3 +478,13 @@ not processed, and counting it would make throughput look healthy during an
 outage.
 
 Configure Grafana to use the collector's Prometheus exporter (`http://localhost:9464`) as a data source.
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for
+the development workflow, the checks that must pass, and how changes are
+reviewed.
+
+## License
+
+Released under the MIT License. See [LICENSE](LICENSE).

--- a/helm/an-ki/Chart.yaml
+++ b/helm/an-ki/Chart.yaml
@@ -2,3 +2,5 @@ apiVersion: v2
 name: an-ki
 version: 0.1.0
 description: Helm chart for deploying principal, An, and Ki nodes
+# Version of an-ki this chart deploys. The image tag defaults to it.
+appVersion: "0.1.0"

--- a/helm/an-ki/templates/an-deployment.yaml
+++ b/helm/an-ki/templates/an-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: an
-          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag }}
+          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag | default .Chart.AppVersion }}
           command: ["an-ki", "an"]
           env:
             - name: AMQP_ADDR

--- a/helm/an-ki/templates/ki-deployment.yaml
+++ b/helm/an-ki/templates/ki-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: ki
-          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag }}
+          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag | default .Chart.AppVersion }}
           command: ["an-ki", "ki"]
           env:
             - name: AMQP_ADDR

--- a/helm/an-ki/templates/principal-statefulset.yaml
+++ b/helm/an-ki/templates/principal-statefulset.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: principal
-          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag }}
+          image: {{ .Values.global.imageRepository }}:{{ .Values.global.imageTag | default .Chart.AppVersion }}
           # The StatefulSet ordinal is the natural source of a stable Raft node
           # id. Raft ids start at 1 here so that 0 never appears as an id.
           command:

--- a/helm/an-ki/values.yaml
+++ b/helm/an-ki/values.yaml
@@ -1,6 +1,8 @@
 global:
   imageRepository: an-ki
-  imageTag: latest
+  # Defaults to the chart appVersion when left empty, so a released chart
+  # pins the image it was tested against instead of floating on `latest`.
+  imageTag: ""
   amqpAddr: amqp://rabbitmq:5672/%2f
   jwtSecretKey: change-me
   databaseUrl: postgresql://user:pass@db:5432/app


### PR DESCRIPTION
> **Stacked on #144 → #143 → main.** Merge bottom-up. (4 of 4 toward v0.1.0.)

Adds what a tagged release needs, and fixes the documentation gaps that would otherwise ship with it.

## Release workflow

Triggered by pushing a `v*` tag. Two things worth noting in the design:

- **It refuses to build when the tag disagrees with the crate version or the chart version.** Artifacts whose embedded version doesn't match the release they hang off are worse than a failed build, and a mistyped tag is easy. The check runs before the build, not after publishing.
- **The GitHub release is created as a draft.** Publishing is a human decision; the workflow gets everything ready and stops.

It runs the full check suite, builds a release binary, packages it with a SHA-256 checksum alongside the packaged Helm chart.

The tarball ships `config/default.example`, **not** `config/default.toml` — the latter carries a placeholder `jwt_secret_key`, and a downloadable artifact containing a ready-to-run secret invites someone to deploy with it.

## CHANGELOG

Documents the release, with a **Known limitations** section stating plainly that:

- the per-shard computation is a placeholder that returns twice its input, so this is the distributed round trip and not a training algorithm;
- the `integration-tests` suite doesn't run in CI;
- the message-encryption key is derived from `jwt_secret_key`, so one secret covers both authentication and confidentiality.

These are real caveats and belong in front of anyone installing this, not buried in commit history.

## Chart versioning

Adds `appVersion: "0.1.0"`, and the image tag now defaults to it rather than floating on `latest`, so a released chart pins the image it was tested against. `imageTag` is still overridable for local builds.

## README: six dead links

The table of contents linked to **Configuration**, **Modules Overview**, **Testing**, **Building**, **Contributing**, and **License** — none of which existed. I wrote all six rather than trimming the contents, since a module table and build/test instructions are worth having. Verified programmatically that every ToC anchor now resolves to a real heading.

## CONTRIBUTING

Covers the checks (including why `--all-targets` matters for clippy), the feature-gated tests, and merging stacked PRs in order — using the `src/lib.rs` conflict from #141 as the worked example of why that matters.

## Verification

`cargo fmt --check`, `cargo test` (121 passing), and all three workflow files parse as valid YAML. The chart renders with the image tag falling back to `appVersion` (`an-ki:0.1.0`); the StatefulSet's `$peers` block is beyond my local renderer, but it's covered by the Rust test pinning the `RAFT_PEERS` string and by the real `helm lint`/`helm template` in Deploy Checks.

I could not execute the release workflow itself — it only fires on a tag push. Its logic is straightforward shell and the YAML parses, but the first real tag is its first real run.

## To cut the release

Once this stack is merged:

```bash
git tag -a v0.1.0 -m "v0.1.0" && git push origin v0.1.0
```

That builds the artifacts and opens a draft release for you to review and publish. **I have not created the tag** — that's the outward-facing step, and it's yours to take.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_