### PR TITLE
Checkpoint the model so a restart does not discard training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disjoint shards so each worker contributes independent gradient signal.
 - Configurable `hidden_units`, `learning_rate`, `dataset_samples`,
   `dataset_seed`, and `init_seed`.
+- **Model checkpointing.** The An node writes parameters to the
+  `model_checkpoints` table every `checkpoint_interval_epochs` and resumes from
+  the most recent checkpoint on startup, so a restart no longer discards the
+  training run. Checkpoints are encrypted at rest and keyed by a fingerprint of
+  the network shape and dataset, so a configuration change starts a fresh run
+  rather than resuming into a mismatched parameter vector.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ completes.
 | `init_seed` | `7` | Seed for the initial parameters |
 | `training_epochs` | `400` | Epochs to dispatch before the scheduler stops |
 | `epoch_interval_ms` | `100` | Delay between epochs |
+| `checkpoint_interval_epochs` | `25` | Epochs between checkpoints; `0` disables them |
+
+### Checkpoints
+
+Every `checkpoint_interval_epochs` the An node writes the current parameters to
+the `model_checkpoints` table, and on startup it restores the most recent
+checkpoint instead of starting from `init_seed`. Without this a restart would
+discard the entire training run.
+
+Checkpoints are keyed by a fingerprint of the network shape and the dataset, so
+changing `hidden_units`, `dataset_samples`, or `dataset_seed` starts a fresh run
+rather than resuming into a parameter vector that no longer fits.
+
+Parameters are encrypted at rest with the same shared secret used for inter-node
+messages: a checkpoint is the entire product of the cluster's work and should not
+be plaintext to anything holding a database connection.
+
+Checkpointing is best-effort. A database that is unavailable stops the node
+remembering its progress, not training.
 
 Each worker computes a real gradient: it rebuilds the shared dataset from its
 seed, takes only its own shard, runs the forward and backward passes, and

--- a/config/default.example
+++ b/config/default.example
@@ -20,3 +20,5 @@ dataset_samples = 512
 dataset_seed = 20260814
 # Seed for the initial parameters.
 init_seed = 7
+# Epochs between model checkpoints. Zero disables checkpointing.
+checkpoint_interval_epochs = 25

--- a/config/default.toml
+++ b/config/default.toml
@@ -22,3 +22,5 @@ dataset_samples = 512
 dataset_seed = 20260814
 # Seed for the initial parameters.
 init_seed = 7
+# Epochs between model checkpoints. Zero disables checkpointing.
+checkpoint_interval_epochs = 25

--- a/migrations/003_reshape_model_checkpoints.sql
+++ b/migrations/003_reshape_model_checkpoints.sql
@@ -1,0 +1,22 @@
+-- The original `model_checkpoints` table was never written to, and its shape
+-- does not fit what a training checkpoint is: it required a `task_id`
+-- referencing the REST API's `tasks` table, which would have forced a bogus
+-- task row into existence for every checkpoint. Nothing depends on the old
+-- shape, so it is replaced outright rather than migrated.
+DROP TABLE IF EXISTS model_checkpoints;
+
+CREATE TABLE IF NOT EXISTS model_checkpoints (
+    checkpoint_id UUID PRIMARY KEY,
+    -- Fingerprint of the network shape and dataset. Parameters are only
+    -- meaningful for the model that produced them, so a configuration change
+    -- starts a new run rather than resuming into a mismatched vector.
+    model_id TEXT NOT NULL,
+    epoch BIGINT NOT NULL,
+    -- Encrypted JSON of the parameter vector.
+    parameters BYTEA NOT NULL,
+    loss REAL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS model_checkpoints_by_run
+    ON model_checkpoints (model_id, epoch DESC);

--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -4,9 +4,10 @@ use std::error::Error;
 use std::io::{Error as IoError, ErrorKind};
 
 use crate::{
-    api,
+    api, checkpoint,
     common::{self, GradientReply, Task, TaskType},
     config::load_settings,
+    database,
     dataset::DatasetSpec,
     health, logging_metrics, messaging,
     model::MlpSpec,
@@ -135,6 +136,34 @@ impl AnNodeState {
             last_epoch_loss: None,
             epochs_completed: 0,
         }
+    }
+
+    /// Resumes from a previously saved checkpoint, replacing the freshly
+    /// initialized parameters and continuing the epoch count.
+    ///
+    /// # Errors
+    /// Returns an error if the checkpoint's parameter vector does not match the
+    /// configured network shape, which would otherwise corrupt every subsequent
+    /// gradient application.
+    pub fn resume_from(
+        &mut self,
+        parameters: Vec<f32>,
+        epochs_completed: u64,
+    ) -> Result<(), Box<dyn Error>> {
+        if parameters.len() != self.parameters.len() {
+            return Err(IoError::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "checkpoint has {} parameters, model expects {}",
+                    parameters.len(),
+                    self.parameters.len()
+                ),
+            )
+            .into());
+        }
+        self.parameters = parameters;
+        self.epochs_completed = epochs_completed;
+        Ok(())
     }
 
     /// The current model parameters.
@@ -284,6 +313,42 @@ impl AnNodeState {
     }
 }
 
+/// Saves a checkpoint when one is due, at most once per completed epoch.
+///
+/// Failures are logged and swallowed: losing a checkpoint costs progress, but
+/// aborting the training loop over it costs more.
+async fn maybe_checkpoint(
+    store: Option<&checkpoint::CheckpointStore>,
+    run_id: &str,
+    state: &Arc<Mutex<AnNodeState>>,
+    interval: u64,
+    last_saved: &mut u64,
+) {
+    let Some(store) = store else {
+        return;
+    };
+
+    let (epoch, parameters, loss) = {
+        let state = state.lock().await;
+        (
+            state.epochs_completed(),
+            state.parameters().to_vec(),
+            state.last_epoch_loss(),
+        )
+    };
+
+    if epoch == *last_saved || !checkpoint::is_checkpoint_due(epoch, interval) {
+        return;
+    }
+
+    match store.save(run_id, epoch, &parameters, loss).await {
+        Ok(_) => *last_saved = epoch,
+        // Do not advance `last_saved` on failure, so the next completed epoch
+        // retries rather than waiting a full interval.
+        Err(e) => error!("Failed to save checkpoint at epoch {}: {:?}", epoch, e),
+    }
+}
+
 pub async fn run() -> Result<(), Box<dyn Error>> {
     #[cfg(unix)]
     if let Err(e) = signals::setup_unix_signal_handlers().await {
@@ -307,13 +372,50 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     // The scheduler dispatches the current parameters each epoch, so the model
     // needs a shape before the first round rather than being inferred from the
     // first gradient to arrive.
-    let state = Arc::new(Mutex::new(AnNodeState::new(
-        settings.model_spec(),
-        settings.dataset_spec(),
+    let model_spec = settings.model_spec();
+    let dataset_spec = settings.dataset_spec();
+    let run_id = checkpoint::model_id(&model_spec, &dataset_spec);
+    let mut state_value = AnNodeState::new(
+        model_spec,
+        dataset_spec,
         shard_count,
         settings.learning_rate,
         settings.init_seed,
-    )));
+    );
+
+    // Restore the last checkpoint so a restart resumes training rather than
+    // discarding it. Checkpointing is best-effort: a database that is
+    // unavailable must not stop the node from training, only from remembering.
+    let checkpoints = match database::get_pool().await {
+        Ok(pool) => match checkpoint::CheckpointStore::new(pool) {
+            Ok(store) => {
+                match store.latest(&run_id, model_spec.parameter_count()).await {
+                    Ok(Some(saved)) => {
+                        match state_value.resume_from(saved.parameters, saved.epoch) {
+                            Ok(()) => info!(
+                                "Resumed {} from checkpoint at epoch {} (loss {:?})",
+                                run_id, saved.epoch, saved.loss
+                            ),
+                            Err(e) => error!("Ignoring incompatible checkpoint: {:?}", e),
+                        }
+                    }
+                    Ok(None) => info!("No checkpoint for {}; starting from the seed", run_id),
+                    Err(e) => error!("Could not read checkpoints: {:?}", e),
+                }
+                Some(store)
+            }
+            Err(e) => {
+                error!("Checkpointing disabled: {:?}", e);
+                None
+            }
+        },
+        Err(e) => {
+            error!("Checkpointing disabled, no database connection: {:?}", e);
+            None
+        }
+    };
+
+    let state = Arc::new(Mutex::new(state_value));
 
     // Serve the task REST API alongside the consumer loop. The server creates
     // its own database-backed task manager and shuts down on the same signal.
@@ -361,6 +463,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let queue_name = "an_task_queue";
     let consumer_tag = "an_consumer";
+    let mut last_checkpointed_epoch = 0_u64;
 
     loop {
         let (channel, mut consumer) = messaging::connect_with_retries(
@@ -425,6 +528,14 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                                         .await;
                                     if outcome.is_ok() {
                                         logging_metrics::record_task_processed(started_at);
+                                        maybe_checkpoint(
+                                            checkpoints.as_ref(),
+                                            &run_id,
+                                            &state,
+                                            settings.checkpoint_interval_epochs,
+                                            &mut last_checkpointed_epoch,
+                                        )
+                                        .await;
                                     }
                                     match outcome {
                                         Ok(()) => {
@@ -684,6 +795,31 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("zero samples"));
+    }
+
+    #[tokio::test]
+    async fn resuming_replaces_the_parameters_and_continues_the_epoch_count() {
+        let mut state = test_state(1);
+        let restored: Vec<f32> = (0..state.parameters().len()).map(|i| i as f32).collect();
+
+        state.resume_from(restored.clone(), 125).expect("resume");
+
+        assert_eq!(state.parameters(), &restored[..]);
+        assert_eq!(state.epochs_completed(), 125);
+    }
+
+    #[tokio::test]
+    async fn a_checkpoint_of_the_wrong_shape_is_refused() {
+        // Loading a mismatched vector would corrupt every gradient applied to
+        // it afterwards, so it must not silently succeed.
+        let mut state = test_state(1);
+        let before = state.parameters().to_vec();
+
+        let err = state.resume_from(vec![0.0; 3], 10).unwrap_err();
+
+        assert!(err.to_string().contains("checkpoint has 3 parameters"));
+        assert_eq!(state.parameters(), &before[..]);
+        assert_eq!(state.epochs_completed(), 0);
     }
 
     #[tokio::test]

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,321 @@
+//! Persistence for trained model parameters.
+//!
+//! Training that is not checkpointed is thrown away: an An node that restarts
+//! after four hundred epochs would otherwise begin again from its initial seed.
+//! This stores the parameter vector to the database periodically and restores
+//! the most recent one at startup.
+//!
+//! Parameters are encrypted at rest with the same shared secret used for
+//! inter-node messages. A checkpoint is the model — the entire product of the
+//! cluster's work — so it should not sit in the database as plaintext readable
+//! by anything holding a connection.
+
+use crate::database::PgPool;
+use crate::dataset::DatasetSpec;
+use crate::error::AnKiError;
+use crate::model::MlpSpec;
+use crate::security;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// A restored checkpoint.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Checkpoint {
+    pub epoch: u64,
+    pub parameters: Vec<f32>,
+    pub loss: Option<f32>,
+}
+
+/// Fingerprint of a training run: the network shape and the dataset it is
+/// trained on.
+///
+/// Parameters are only meaningful for the model that produced them, so this is
+/// what keeps a configuration change from resuming into a mismatched vector.
+/// Changing the hidden width, the dataset size, or the dataset seed all start a
+/// new run rather than silently loading incompatible weights.
+pub fn model_id(spec: &MlpSpec, dataset: &DatasetSpec) -> String {
+    format!(
+        "in{}-h{}-out{}-n{}-seed{}",
+        spec.inputs, spec.hidden, spec.outputs, dataset.samples, dataset.seed
+    )
+}
+
+/// Whether a checkpoint is due after completing `epoch`.
+///
+/// Epoch zero means nothing has completed yet. An interval of zero disables
+/// periodic checkpointing rather than dividing by zero.
+pub fn is_checkpoint_due(epoch: u64, interval: u64) -> bool {
+    interval != 0 && epoch != 0 && epoch.is_multiple_of(interval)
+}
+
+/// Encrypts a parameter vector for storage.
+pub fn encode(parameters: &[f32], key: &str) -> Result<Vec<u8>, AnKiError> {
+    let json = serde_json::to_string(parameters)
+        .map_err(|e| AnKiError::TaskRecovery(format!("failed to serialize parameters: {e}")))?;
+    Ok(security::encrypt_message(&json, key)?.into_bytes())
+}
+
+/// Decrypts a stored parameter vector.
+pub fn decode(stored: &[u8], key: &str) -> Result<Vec<f32>, AnKiError> {
+    let encoded = std::str::from_utf8(stored).map_err(|_| AnKiError::InvalidCiphertext)?;
+    let json = security::decrypt_message(encoded, key)?;
+    serde_json::from_str(&json)
+        .map_err(|e| AnKiError::TaskRecovery(format!("failed to decode parameters: {e}")))
+}
+
+/// Stores and retrieves model checkpoints.
+#[derive(Clone)]
+pub struct CheckpointStore {
+    pool: PgPool,
+    key: String,
+}
+
+impl CheckpointStore {
+    /// Builds a store, taking the encryption key from the shared node secret.
+    pub fn new(pool: PgPool) -> Result<Self, AnKiError> {
+        Ok(Self {
+            pool,
+            key: security::message_key()?,
+        })
+    }
+
+    /// Writes a checkpoint for `model_id` at `epoch`.
+    pub async fn save(
+        &self,
+        model_id: &str,
+        epoch: u64,
+        parameters: &[f32],
+        loss: Option<f32>,
+    ) -> Result<Uuid, AnKiError> {
+        let ciphertext = encode(parameters, &self.key)?;
+        let checkpoint_id = Uuid::new_v4();
+
+        let connection = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
+        connection
+            .execute(
+                "INSERT INTO model_checkpoints \
+                 (checkpoint_id, model_id, epoch, parameters, loss) \
+                 VALUES ($1, $2, $3, $4, $5)",
+                &[
+                    &checkpoint_id,
+                    &model_id,
+                    &(epoch as i64),
+                    &ciphertext,
+                    &loss,
+                ],
+            )
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
+
+        info!(
+            "Saved checkpoint {} for {} at epoch {}",
+            checkpoint_id, model_id, epoch
+        );
+        Ok(checkpoint_id)
+    }
+
+    /// Reads the most recent checkpoint for `model_id`, if any.
+    ///
+    /// `expected_parameters` guards against restoring a vector of the wrong
+    /// length. The model id already encodes the shape, so a mismatch means the
+    /// stored row is corrupt or was written by an incompatible version; either
+    /// way it is discarded rather than loaded.
+    pub async fn latest(
+        &self,
+        model_id: &str,
+        expected_parameters: usize,
+    ) -> Result<Option<Checkpoint>, AnKiError> {
+        let connection = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
+        let row = connection
+            .query_opt(
+                "SELECT epoch, parameters, loss FROM model_checkpoints \
+                 WHERE model_id = $1 ORDER BY epoch DESC LIMIT 1",
+                &[&model_id],
+            )
+            .await
+            .map_err(|e| AnKiError::TaskRecovery(e.to_string()))?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+
+        let epoch: i64 = row.get("epoch");
+        let stored: Vec<u8> = row.get("parameters");
+        let loss: Option<f32> = row.get("loss");
+        let parameters = decode(&stored, &self.key)?;
+
+        if parameters.len() != expected_parameters {
+            warn!(
+                "Discarding checkpoint for {}: expected {} parameters, stored row has {}",
+                model_id,
+                expected_parameters,
+                parameters.len()
+            );
+            return Ok(None);
+        }
+
+        Ok(Some(Checkpoint {
+            epoch: epoch.max(0) as u64,
+            parameters,
+            loss,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> MlpSpec {
+        MlpSpec::new(2, 16, 2)
+    }
+
+    fn dataset() -> DatasetSpec {
+        DatasetSpec::new(512, 20_260_814)
+    }
+
+    #[test]
+    fn the_model_id_changes_with_anything_that_changes_the_parameters() {
+        let base = model_id(&spec(), &dataset());
+
+        assert_eq!(base, model_id(&spec(), &dataset()), "must be stable");
+        assert_ne!(
+            base,
+            model_id(&MlpSpec::new(2, 8, 2), &dataset()),
+            "a different hidden width is a different parameter vector"
+        );
+        assert_ne!(
+            base,
+            model_id(&spec(), &DatasetSpec::new(512, 1)),
+            "a different dataset seed is a different training run"
+        );
+        assert_ne!(
+            base,
+            model_id(&spec(), &DatasetSpec::new(256, 20_260_814)),
+            "a different dataset size is a different training run"
+        );
+    }
+
+    #[test]
+    fn parameters_round_trip_through_encryption() {
+        let parameters = spec().initialize(3);
+        let key = "checkpoint-test-key";
+
+        let stored = encode(&parameters, key).expect("encode");
+        let restored = decode(&stored, key).expect("decode");
+
+        assert_eq!(restored, parameters);
+    }
+
+    #[test]
+    fn stored_parameters_are_not_readable_without_the_key() {
+        // A checkpoint is the entire product of the cluster's work; it should
+        // not sit in the database as plaintext.
+        let parameters = vec![1.5_f32, -2.25, 3.0];
+        let stored = encode(&parameters, "right-key").expect("encode");
+
+        assert!(decode(&stored, "wrong-key").is_err());
+        let as_text = String::from_utf8_lossy(&stored);
+        assert!(!as_text.contains("1.5"), "parameters appeared in plaintext");
+    }
+
+    #[test]
+    fn corrupt_ciphertext_is_an_error_rather_than_a_panic() {
+        assert!(decode(b"not-ciphertext", "key").is_err());
+        assert!(decode(&[0xff, 0xfe], "key").is_err());
+    }
+
+    #[test]
+    fn checkpoints_are_due_on_the_interval_only() {
+        assert!(!is_checkpoint_due(0, 25), "nothing has completed yet");
+        assert!(!is_checkpoint_due(24, 25));
+        assert!(is_checkpoint_due(25, 25));
+        assert!(is_checkpoint_due(50, 25));
+        assert!(!is_checkpoint_due(51, 25));
+    }
+
+    #[test]
+    fn a_zero_interval_disables_checkpointing_rather_than_dividing_by_zero() {
+        assert!(!is_checkpoint_due(10, 0));
+    }
+
+    // These need a live database, so they are gated behind the same feature as
+    // the rest of the database-backed tests.
+    #[cfg(feature = "integration-tests")]
+    mod database_tests {
+        use super::*;
+        use crate::database::get_pool;
+
+        async fn store() -> CheckpointStore {
+            CheckpointStore::new(get_pool().await.expect("pool")).expect("store")
+        }
+
+        #[tokio::test]
+        async fn a_saved_checkpoint_comes_back() {
+            let store = store().await;
+            let run = format!("test-{}", Uuid::new_v4());
+            let parameters = spec().initialize(5);
+
+            store
+                .save(&run, 42, &parameters, Some(0.25))
+                .await
+                .expect("save");
+            let restored = store
+                .latest(&run, parameters.len())
+                .await
+                .expect("read")
+                .expect("checkpoint present");
+
+            assert_eq!(restored.epoch, 42);
+            assert_eq!(restored.parameters, parameters);
+            assert_eq!(restored.loss, Some(0.25));
+        }
+
+        #[tokio::test]
+        async fn the_most_recent_epoch_wins() {
+            let store = store().await;
+            let run = format!("test-{}", Uuid::new_v4());
+            let early = spec().initialize(1);
+            let late = spec().initialize(2);
+
+            store.save(&run, 10, &early, None).await.expect("save");
+            store.save(&run, 20, &late, None).await.expect("save");
+
+            let restored = store
+                .latest(&run, late.len())
+                .await
+                .expect("read")
+                .expect("present");
+            assert_eq!(restored.epoch, 20);
+            assert_eq!(restored.parameters, late);
+        }
+
+        #[tokio::test]
+        async fn an_unknown_run_has_no_checkpoint() {
+            let store = store().await;
+            let run = format!("never-saved-{}", Uuid::new_v4());
+            assert!(store.latest(&run, 8).await.expect("read").is_none());
+        }
+
+        #[tokio::test]
+        async fn a_row_of_the_wrong_shape_is_discarded_rather_than_returned() {
+            let store = store().await;
+            let run = format!("test-{}", Uuid::new_v4());
+            store
+                .save(&run, 1, &[1.0, 2.0, 3.0], None)
+                .await
+                .expect("save");
+
+            // Ask for a model that expects a different parameter count.
+            assert!(store.latest(&run, 99).await.expect("read").is_none());
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,9 @@ pub struct Settings {
     /// Seed for the initial parameters.
     #[serde(default = "default_init_seed")]
     pub init_seed: u64,
+    /// Epochs between model checkpoints. Zero disables checkpointing.
+    #[serde(default = "default_checkpoint_interval_epochs")]
+    pub checkpoint_interval_epochs: u64,
     /// Milliseconds between training epochs.
     #[serde(default = "default_epoch_interval_ms")]
     pub epoch_interval_ms: u64,
@@ -60,6 +63,10 @@ fn default_dataset_seed() -> u64 {
 
 fn default_init_seed() -> u64 {
     7
+}
+
+fn default_checkpoint_interval_epochs() -> u64 {
+    25
 }
 
 fn default_epoch_interval_ms() -> u64 {
@@ -232,6 +239,7 @@ mod tests {
             dataset_samples: 64,
             dataset_seed: 1,
             init_seed: 1,
+            checkpoint_interval_epochs: 25,
             epoch_interval_ms: 250,
         }
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -21,6 +21,12 @@ async fn run_migrations(pool: &PgPool) -> Result<(), Box<dyn Error + Send + Sync
     ))
     .await?;
 
+    // Reshaped to fit training checkpoints rather than REST API tasks.
+    conn.batch_execute(include_str!(
+        "../migrations/003_reshape_model_checkpoints.sql"
+    ))
+    .await?;
+
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod an_node;
 pub mod api;
+pub mod checkpoint;
 pub mod common;
 pub mod config;
 pub mod database;


### PR DESCRIPTION
First of three follow-ups now that training is real. **`model_checkpoints` was created by migration 002 and never written to or read from.** An An node that restarted after 400 epochs began again from its initial seed, throwing away the entire product of the cluster's work.

## The table couldn't hold a checkpoint

The original schema required `task_id UUID NOT NULL REFERENCES tasks(task_id)` — a foreign key to the REST API's `tasks` table, which a training checkpoint has nothing to do with. Writing one would have meant forcing a bogus task row into existence first.

Nothing had ever written to it, so migration 003 replaces the shape outright rather than migrating it: `model_id`, `epoch`, encrypted `parameters`, `loss`, indexed by `(model_id, epoch DESC)`.

## Keyed by what makes parameters meaningful

Checkpoints are keyed by a fingerprint of the network shape and dataset (`in2-h16-out2-n512-seed20260814`). Parameters are only meaningful for the model that produced them, so changing `hidden_units`, `dataset_samples`, or `dataset_seed` starts a **fresh run** rather than resuming into a vector that no longer fits.

The stored length is checked again on load and a mismatch is discarded rather than applied — a wrong-length restore would corrupt every gradient applied afterwards. `resume_from` rejects it as a second guard at the state level.

## Encrypted at rest

A checkpoint is the whole model. It shouldn't be readable by anything that merely holds a database connection, so parameters are encrypted with the same shared secret used for inter-node messages. There's a test asserting the stored bytes don't contain the parameter values in plaintext and don't decode under a wrong key.

This also gives the AES-GCM message encryption a genuine user — relevant to the next PR, which removes its current one.

## Best-effort throughout

A database unavailable at startup, or a write that fails mid-run, stops the node *remembering* its progress — not training. A failed save deliberately does **not** advance the last-saved epoch, so the next completed epoch retries rather than waiting a full interval.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 148 → 156.

Default-run tests cover the parts that don't need a database: model-id fingerprinting, the encryption round trip, plaintext/wrong-key rejection, corrupt-ciphertext handling, checkpoint-due arithmetic (including the zero-interval divide-by-zero), and `resume_from` accepting a good vector and refusing a mismatched one.

**Four database round-trip tests are behind `integration-tests` and therefore do not run in CI** — save/restore, most-recent-epoch-wins, unknown run, and wrong-shape discard. I have no Postgres available here, so those are written but unexecuted. That's the same gap I've flagged before and it keeps widening; getting service containers into CI is worth doing next.

## New setting

| Setting | Default | Purpose |
| --- | --- | --- |
| `checkpoint_interval_epochs` | `25` | Epochs between checkpoints; `0` disables |

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_