### PR TITLE
Remove the parameter broadcast nothing consumed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `model_dimension`, superseded by `hidden_units` — the parameter count now
   follows from the network shape.
+- The `ki_model_queue` parameter broadcast. An nodes encrypted and published
+  updated parameters every epoch, Ki nodes decrypted them into a field nothing
+  read, and gradient requests already carry the parameters they are evaluated
+  at. Removing it also removes a 100,000-iteration key derivation from a path
+  that ran on every epoch.
+- `messaging::encrypt_payload`, `decrypt_payload`, and `publish_encrypted`,
+  whose only caller was that broadcast. Checkpoint encryption uses the
+  `security` primitives directly.
 
 ## [0.1.0] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A distributed neural network: a multi-layer perceptron trained data-parallel acr
 
 - **Task Scheduling:** An nodes dispatch one task per model shard each epoch onto `ki_task_queue`; the broker distributes them across whichever Ki nodes are alive.
 - **Fault Tolerance:** Tasks are persisted to the database by the task recovery manager, so they survive a node restart and can be recovered by ID.
-- **Secure Communication:** JWT-based authentication and role-based access control on the REST API, plus AES-256-GCM encryption of model-update messages exchanged between nodes (keyed by `jwt_secret_key`).
+- **Secure Communication:** JWT-based authentication and role-based access control on the REST API, plus AES-256-GCM encryption of model checkpoints at rest (keyed by `jwt_secret_key`).
 - **Dynamic Node Discovery:** The principal derives a live cluster view from node heartbeats — nodes join by heartbeating and are evicted after `NODE_TTL_MS` of silence. No separate registration step is required.
 - **Consensus & Leader Election:** Uses the Raft protocol (via [`openraft`](https://github.com/datafuselabs/openraft)) for a replicated, consistent log and automatic leader election, over a durable [`sled`](https://github.com/spacejam/sled)-backed log that survives restarts. Principals replicate to each other over HTTP, so a multi-principal cluster tolerates the loss of a minority of its members.
 - **Monitoring and Metrics:** Prometheus metrics for task throughput and latency, plus a `consensus_state` gauge driven by real Raft leadership, and OpenTelemetry tracing.
@@ -168,12 +168,16 @@ consumes from that queue, so the broker spreads the shards across whichever
 workers are alive.
 
 ```
-An scheduler ──(model_shards tasks)──▶ ki_task_queue ──▶ Ki nodes
-                                                            │
-An node ◀────────(gradients)──────── an_task_queue ◀────────┘
+An scheduler ──(model_shards gradient requests)──▶ ki_task_queue ──▶ Ki nodes
+                                                                        │
+An node ◀──────────(gradients + loss)──────── an_task_queue ◀───────────┘
    │
-   └──(after model_shards gradients: average, update)──▶ ki_model_queue ──▶ Ki nodes
+   └──(after model_shards gradients: weighted average, one descent step)
 ```
+
+Each request carries the parameters to evaluate at, so workers hold no model
+state between rounds and a worker can join, restart, or disappear without
+resynchronizing anything.
 
 The shard count is load-bearing rather than a tuning knob: the An node
 accumulates gradients and only publishes an updated model once `model_shards`

--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -11,19 +11,15 @@ use crate::{
     dataset::DatasetSpec,
     health, logging_metrics, messaging,
     model::MlpSpec,
-    scheduler, security, signals,
+    scheduler, signals,
 };
 use futures_util::stream::StreamExt;
-use lapin::{
-    options::{BasicAckOptions, BasicNackOptions},
-    Channel,
-};
+use lapin::options::{BasicAckOptions, BasicNackOptions};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{watch, Mutex};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
-use uuid::Uuid;
+use tracing::{error, info, warn};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DeliveryDisposition {
@@ -197,30 +193,27 @@ impl AnNodeState {
         self.epochs_completed
     }
 
-    /// Folds one worker's reply into the current epoch, applying the update and
-    /// broadcasting the new model once every shard has reported.
-    pub async fn process_task(
-        &mut self,
-        task: Task,
-        channel: Option<&Channel>,
-    ) -> Result<(), Box<dyn Error>> {
+    /// Folds one worker's reply into the current epoch, applying the update once
+    /// every shard has reported.
+    pub async fn process_task(&mut self, task: Task) -> Result<(), Box<dyn Error>> {
         match task.task_type {
             TaskType::GradientUpdate => {
                 let reply: GradientReply = serde_json::from_str(&task.data)?;
                 self.accumulate(reply)?;
 
                 if self.replies >= self.shards {
-                    let model = self.apply_epoch();
-                    if let Some(ch) = channel {
-                        self.broadcast_model(&model, ch).await?;
-                    }
+                    self.apply_epoch();
                 }
             }
             TaskType::ParameterPull => {
-                if let Some(ch) = channel {
-                    let model = self.parameters.clone();
-                    self.broadcast_model(&model, ch).await?;
-                }
+                // Workers receive parameters in their gradient request, so there
+                // is nothing to push. The variant remains a valid task type for
+                // the REST task API, which is unrelated to training.
+                warn!(
+                    "Ignoring ParameterPull task {}: parameters travel with each \
+                     gradient request",
+                    task.task_id
+                );
             }
         }
         Ok(())
@@ -270,7 +263,7 @@ impl AnNodeState {
     }
 
     /// Applies the accumulated gradient and resets for the next epoch.
-    fn apply_epoch(&mut self) -> Vec<f32> {
+    fn apply_epoch(&mut self) {
         let total = self.accumulated_samples as f32;
         for (parameter, accumulated) in self.parameters.iter_mut().zip(&self.accumulator) {
             *parameter -= self.learning_rate * (accumulated / total);
@@ -291,25 +284,6 @@ impl AnNodeState {
         self.accumulated_samples = 0;
         self.loss_accumulator = 0.0;
         self.replies = 0;
-        self.parameters.clone()
-    }
-
-    async fn broadcast_model(
-        &self,
-        model: &[f32],
-        channel: &Channel,
-    ) -> Result<(), Box<dyn Error>> {
-        let task = Task {
-            task_id: Uuid::new_v4(),
-            task_type: TaskType::ParameterPull,
-            data: serde_json::to_string(model)?,
-        };
-        messaging::declare_queue(channel, "ki_model_queue").await?;
-        // Encrypt the model parameters in transit with the shared node secret.
-        let key = security::message_key()?;
-        messaging::publish_encrypted(channel, "ki_model_queue", &task, &key).await?;
-        info!("Broadcasted model update");
-        Ok(())
     }
 }
 
@@ -466,7 +440,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     let mut last_checkpointed_epoch = 0_u64;
 
     loop {
-        let (channel, mut consumer) = messaging::connect_with_retries(
+        let (_channel, mut consumer) = messaging::connect_with_retries(
             &amqp_addr,
             queue_name,
             consumer_tag,
@@ -524,7 +498,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                                     let outcome = state
                                         .lock()
                                         .await
-                                        .process_task(task_message, Some(&channel))
+                                        .process_task(task_message)
                                         .await;
                                     if outcome.is_ok() {
                                         logging_metrics::record_task_processed(started_at);
@@ -606,6 +580,7 @@ mod tests {
     use super::*;
     use crate::common::{Task, TaskType};
     use std::io::{Error as IoError, ErrorKind};
+    use uuid::Uuid;
 
     #[test]
     fn test_successful_processing_disposition_acknowledges() {
@@ -687,7 +662,7 @@ mod tests {
         let gradient = vec![1.0_f32; before.len()];
 
         state
-            .process_task(reply_task(gradient, 0.5, 10), None)
+            .process_task(reply_task(gradient, 0.5, 10))
             .await
             .expect("accepted");
 
@@ -709,11 +684,11 @@ mod tests {
         let width = before.len();
 
         state
-            .process_task(reply_task(vec![1.0; width], 1.0, 10), None)
+            .process_task(reply_task(vec![1.0; width], 1.0, 10))
             .await
             .expect("accepted");
         state
-            .process_task(reply_task(vec![4.0; width], 4.0, 20), None)
+            .process_task(reply_task(vec![4.0; width], 4.0, 20))
             .await
             .expect("accepted");
 
@@ -732,7 +707,7 @@ mod tests {
         let before = state.parameters().to_vec();
 
         let err = state
-            .process_task(reply_task(vec![1.0; 3], 0.1, 5), None)
+            .process_task(reply_task(vec![1.0; 3], 0.1, 5))
             .await
             .unwrap_err();
 
@@ -773,7 +748,7 @@ mod tests {
         let width = before.len();
 
         let err = state
-            .process_task(reply_task(vec![f32::INFINITY; width], 0.1, 5), None)
+            .process_task(reply_task(vec![f32::INFINITY; width], 0.1, 5))
             .await
             .unwrap_err();
 
@@ -790,7 +765,7 @@ mod tests {
         let width = state.parameters().len();
 
         let err = state
-            .process_task(reply_task(vec![1.0; width], 0.1, 0), None)
+            .process_task(reply_task(vec![1.0; width], 0.1, 0))
             .await
             .unwrap_err();
 
@@ -843,7 +818,7 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn test_setup_consumer_workflow() {
-        let (channel, mut consumer) = messaging::connect_with_retries(
+        let (_channel, mut consumer) = messaging::connect_with_retries(
             AMQP_ADDR,
             "test_queue",
             "test_consumer",

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -8,7 +8,6 @@ use crate::health;
 use crate::logging_metrics;
 use crate::messaging;
 use crate::model;
-use crate::security;
 use crate::signals;
 use futures_util::stream::StreamExt;
 use lapin::{
@@ -88,29 +87,6 @@ fn normalize_reconnect_attempts(raw: u32) -> u32 {
     }
 }
 
-#[derive(Default)]
-struct KiNodeState {
-    model_params: Vec<f32>,
-}
-
-impl KiNodeState {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn update_model(&mut self, task: &Task) -> Result<(), serde_json::Error> {
-        let params: Vec<f32> = serde_json::from_str(&task.data)?;
-        self.model_params = params;
-        info!("Updated local model parameters");
-        Ok(())
-    }
-
-    #[cfg(test)]
-    fn parameters(&self) -> &[f32] {
-        &self.model_params
-    }
-}
-
 fn deserialize_task_message(queue_name: &str, payload: &[u8]) -> Result<Task, serde_json::Error> {
     serde_json::from_slice::<Task>(payload).map_err(|e| {
         error!(
@@ -167,26 +143,12 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 
     let queue_name = "ki_task_queue";
     let consumer_tag = "ki_consumer";
-    let model_queue_name = "ki_model_queue";
-    let model_consumer_tag = "ki_model_consumer";
-
-    let mut state = KiNodeState::new();
 
     loop {
         let (channel, mut consumer) = messaging::connect_with_retries(
             &amqp_addr,
             queue_name,
             consumer_tag,
-            max_retries,
-            backoff_ms,
-            max_backoff_ms,
-        )
-        .await?;
-
-        let (_model_channel, mut model_consumer) = messaging::connect_with_retries(
-            &amqp_addr,
-            model_queue_name,
-            model_consumer_tag,
             max_retries,
             backoff_ms,
             max_backoff_ms,
@@ -263,56 +225,6 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
                         }
                         None => {
                             error!("Consumer stream closed");
-                            break;
-                        }
-                    }
-                }
-                model_delivery = model_consumer.next() => {
-                    match model_delivery {
-                        Some(Ok(delivery)) => {
-                            let parsed = security::message_key().and_then(|key| {
-                                messaging::decrypt_payload::<Task>(&delivery.data, &key)
-                            });
-                            match parsed {
-                                Ok(task_message) => match state.update_model(&task_message) {
-                                    Ok(()) => {
-                                        if let Err(e) = delivery.ack(BasicAckOptions::default()).await {
-                                            error!("Failed to acknowledge model update: {:?}", e);
-                                        }
-                                    }
-                                    Err(e) => {
-                                        error!(
-                                            "Dropping invalid model update without requeue: {:?}",
-                                            e
-                                        );
-                                        if let Err(e) = delivery.nack(nack_options(false)).await {
-                                            error!(
-                                                "Failed to negatively acknowledge model update: {:?}",
-                                                e
-                                            );
-                                        }
-                                    }
-                                },
-                                Err(e) => {
-                                    error!(
-                                        "Dropping undecryptable or malformed model update without requeue: {:?}",
-                                        e
-                                    );
-                                    if let Err(e) = delivery.nack(nack_options(false)).await {
-                                        error!(
-                                            "Failed to negatively acknowledge model update: {:?}",
-                                            e
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                        Some(Err(e)) => {
-                            error!("Error in model consumer stream: {:?}", e);
-                            break;
-                        }
-                        None => {
-                            error!("Model consumer stream closed");
                             break;
                         }
                     }
@@ -455,19 +367,6 @@ mod tests {
     #[test]
     fn high_reconnect_attempt_count_is_preserved() {
         assert_eq!(normalize_reconnect_attempts(100), 100);
-    }
-
-    #[test]
-    fn test_update_model_parameters() {
-        let mut state = KiNodeState::new();
-        let task = Task {
-            task_id: uuid::Uuid::new_v4(),
-            task_type: TaskType::ParameterPull,
-            data: serde_json::to_string(&vec![1.0_f32, 2.5_f32]).unwrap(),
-        };
-
-        state.update_model(&task).unwrap();
-        assert_eq!(state.parameters(), &[1.0_f32, 2.5_f32]);
     }
 
     #[tokio::test]
@@ -642,52 +541,5 @@ mod tests {
             .ack(BasicAckOptions::default())
             .await
             .expect("ack result");
-    }
-
-    #[cfg(feature = "integration-tests")]
-    #[tokio::test]
-    async fn test_model_update_consumption() {
-        use futures_util::StreamExt;
-        use tokio::time::{timeout, Duration};
-
-        const AMQP_ADDR: &str = "amqp://127.0.0.1:5672/%2f";
-
-        let channel = match messaging::establish_connection(AMQP_ADDR).await {
-            Ok(ch) => ch,
-            Err(_) => return, // RabbitMQ not available
-        };
-
-        messaging::declare_queue(&channel, "ki_model_queue")
-            .await
-            .expect("declare model queue");
-
-        let payload_task = Task {
-            task_id: uuid::Uuid::new_v4(),
-            task_type: TaskType::ParameterPull,
-            data: serde_json::to_string(&vec![0.5_f32, -1.0_f32]).unwrap(),
-        };
-
-        let key = "test-model-key";
-        messaging::publish_encrypted(&channel, "ki_model_queue", &payload_task, key)
-            .await
-            .expect("publish model update");
-
-        let mut consumer =
-            messaging::consume_messages(&channel, "ki_model_queue", "test_model_consumer")
-                .await
-                .expect("consume model queue");
-
-        if let Ok(Some(Ok(delivery))) = timeout(Duration::from_secs(5), consumer.next()).await {
-            let task: Task =
-                messaging::decrypt_payload(&delivery.data, key).expect("decrypt model task");
-            let mut state = KiNodeState::new();
-            state.update_model(&task).expect("update model");
-            assert_eq!(state.parameters(), &[0.5_f32, -1.0_f32]);
-
-            delivery
-                .ack(BasicAckOptions::default())
-                .await
-                .expect("ack model update");
-        }
     }
 }

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -1,15 +1,12 @@
 // messaging.rs: Implements RabbitMQ messaging logic, including sending and receiving messages across the network.
 
 use crate::error::AnKiError;
-use crate::security::{decrypt_message, encrypt_message};
 use lapin::{
     options::*,
     publisher_confirm::{Confirmation, PublisherConfirm},
     types::FieldTable,
     BasicProperties, Channel, Connection, ConnectionProperties,
 };
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::error::Error;
 use tokio::time::{sleep, Duration};
 use tracing::{error, info};
@@ -94,33 +91,6 @@ pub async fn publish_message(
     }
 }
 
-/// Serializes `value` to JSON and encrypts it with `key` (AES-256-GCM),
-/// returning the bytes to publish. Pairs with [`decrypt_payload`].
-pub fn encrypt_payload<T: Serialize>(value: &T, key: &str) -> Result<Vec<u8>, AnKiError> {
-    let json = serde_json::to_string(value).map_err(|e| AnKiError::Messaging(e.to_string()))?;
-    Ok(encrypt_message(&json, key)?.into_bytes())
-}
-
-/// Decrypts a payload produced by [`encrypt_payload`] and deserializes it from
-/// JSON. Returns [`AnKiError::InvalidCiphertext`] if `payload` is not valid
-/// ciphertext for `key`.
-pub fn decrypt_payload<T: DeserializeOwned>(payload: &[u8], key: &str) -> Result<T, AnKiError> {
-    let encoded = std::str::from_utf8(payload).map_err(|_| AnKiError::InvalidCiphertext)?;
-    let json = decrypt_message(encoded, key)?;
-    serde_json::from_str(&json).map_err(|e| AnKiError::Messaging(e.to_string()))
-}
-
-/// Encrypts `value` with `key` and publishes the ciphertext to `queue_name`.
-pub async fn publish_encrypted<T: Serialize>(
-    channel: &Channel,
-    queue_name: &str,
-    value: &T,
-    key: &str,
-) -> Result<(), AnKiError> {
-    let payload = encrypt_payload(value, key)?;
-    publish_message(channel, queue_name, &payload).await
-}
-
 pub async fn consume_messages(
     channel: &Channel,
     queue_name: &str,
@@ -202,42 +172,8 @@ pub async fn connect_with_retries(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::{Task, TaskType};
     use tokio::sync::broadcast;
     use tokio::time::{timeout, Duration};
-    use uuid::Uuid;
-
-    fn sample_task() -> Task {
-        Task {
-            task_id: Uuid::new_v4(),
-            task_type: TaskType::ParameterPull,
-            data: "model-parameters".to_string(),
-        }
-    }
-
-    #[test]
-    fn encrypt_then_decrypt_round_trips_a_task() {
-        let task = sample_task();
-        let key = "shared-node-secret";
-        let payload = encrypt_payload(&task, key).expect("encrypt");
-        // Ciphertext must not contain the plaintext.
-        assert!(!payload.windows(5).any(|w| w == b"model"));
-        let decoded: Task = decrypt_payload(&payload, key).expect("decrypt");
-        assert_eq!(decoded.task_id, task.task_id);
-        assert_eq!(decoded.task_type, task.task_type);
-        assert_eq!(decoded.data, task.data);
-    }
-
-    #[test]
-    fn decrypt_payload_rejects_a_different_key() {
-        let payload = encrypt_payload(&sample_task(), "key-a").expect("encrypt");
-        assert!(decrypt_payload::<Task>(&payload, "key-b").is_err());
-    }
-
-    #[test]
-    fn decrypt_payload_rejects_non_ciphertext() {
-        assert!(decrypt_payload::<Task>(b"not ciphertext", "key").is_err());
-    }
 
     #[cfg(feature = "integration-tests")]
     use futures_util::StreamExt;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -266,7 +266,7 @@ mod tests {
                     .await
                     .expect("ki computes a gradient");
                 state
-                    .process_task(reply, None)
+                    .process_task(reply)
                     .await
                     .expect("an node accepts the gradient");
             }
@@ -336,7 +336,7 @@ mod tests {
             .take(2)
         {
             let reply = ki_node::perform_computation(task).await.expect("gradient");
-            state.process_task(reply, None).await.expect("accepted");
+            state.process_task(reply).await.expect("accepted");
         }
 
         assert_eq!(state.parameters(), &before[..]);


### PR DESCRIPTION
> **Stacked on #149.** Merge that first. (2 of 3.)

Every epoch an An node derived a key, encrypted the updated parameters, and published them to `ki_model_queue`. Every Ki node consumed that queue, decrypted the payload, and stored it in `KiNodeState::model_params` — **a field no code ever read.** `perform_computation` uses the parameters carried in the gradient request, and always has.

## The cost

At the default 100ms epoch interval, that path ran a **100,000-iteration PBKDF2 derivation**, an AES encryption, a broadcast, and a decryption *ten times a second* to produce a value nobody looked at.

## Self-contained requests are also the better design

This isn't only about deleting waste. Because each request carries the parameters to evaluate at:

- a worker holds no model state between rounds, so it can join, restart, or vanish without resynchronizing anything;
- there is no window in which a worker computes a gradient against parameters the An node has already moved past.

A push-based parameter server would save bandwidth (~1KB per request here), but it would need versioning and staleness handling to be correct. Not worth it at this payload size.

## Removed

- `KiNodeState`, and the Ki node's second AMQP connection and consumer
- `AnNodeState::broadcast_model`, and the `channel` argument that existed only to carry it
- `messaging::encrypt_payload`, `decrypt_payload`, `publish_encrypted` — no other caller; checkpoint encryption (#149) uses the `security` primitives directly

`TaskType::ParameterPull` **stays**. It's still a valid task type for the REST task API, which has nothing to do with training — removing it would ripple into `api`, `task_recovery`, and `messaging` tests for no benefit. But an An node that receives one now logs that it's ignoring it rather than silently doing nothing.

## The README was claiming something no longer true

It advertised AES-256-GCM protecting "model-update messages exchanged between nodes". After this change that's true of no message at all. The bullet now describes what encryption actually protects: **checkpoints at rest**. That ordering is why #149 lands first — encryption never passes through a window with no user.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 156 → 152. The four removed tests all covered the deleted path (`KiNodeState` model updates, the encrypted-payload round trip, and its two rejection cases).

Worth noting: the removed `test_model_update_consumption` was one of the few tests exercising a real broker under `integration-tests`. Its subject no longer exists, but that does mean slightly less integration surface — moot while that suite still doesn't run in CI, which remains the biggest verification gap.