### PR TITLE
Hold out a validation set so accuracy means something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disjoint shards so each worker contributes independent gradient signal.
 - Configurable `hidden_units`, `learning_rate`, `dataset_samples`,
   `dataset_seed`, and `init_seed`.
+- **A held-out validation split.** `validation_fraction` (default 0.2) reserves
+  part of the dataset for evaluation. Shards are cut from the training portion
+  only, so no worker computes a gradient on a validation sample, and the An node
+  reports accuracy on unseen data after each epoch.
 - **Model checkpointing.** The An node writes parameters to the
   `model_checkpoints` table every `checkpoint_interval_epochs` and resumes from
   the most recent checkpoint on startup, so a restart no longer discards the

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ completes.
 | `model_shards` | `1` | Shards per epoch, and gradients required to close a round |
 | `hidden_units` | `16` | Hidden layer width; the parameter count follows from it |
 | `learning_rate` | `1.0` | Step size applied to the averaged gradient |
-| `dataset_samples` | `512` | Size of the generated training set |
+| `dataset_samples` | `512` | Size of the generated dataset |
+| `validation_fraction` | `0.2` | Fraction held out for evaluation rather than training |
 | `dataset_seed` | `20260814` | Dataset seed — every node must agree on it |
 | `init_seed` | `7` | Seed for the initial parameters |
 | `training_epochs` | `400` | Epochs to dispatch before the scheduler stops |
@@ -232,7 +233,13 @@ genuinely used its hidden layer rather than collapsing to a linear fit.
 dataset from `dataset_seed` and takes its own shard, so payloads stay
 proportional to the model rather than to the data.
 
-With the shipped defaults the model reaches about 99% accuracy over 400 epochs.
+**A fifth of the data is held out.** Shards are cut from the training portion
+only, so no worker ever computes a gradient on a validation sample. The An node
+reports accuracy on that held-out set after every epoch — accuracy over the
+training data would only measure how well the model memorized it.
+
+With the shipped defaults the model reaches roughly 99% accuracy on data it
+never trained on, over 400 epochs.
 
 ## Getting Started
 

--- a/config/default.example
+++ b/config/default.example
@@ -22,3 +22,5 @@ dataset_seed = 20260814
 init_seed = 7
 # Epochs between model checkpoints. Zero disables checkpointing.
 checkpoint_interval_epochs = 25
+# Fraction of the dataset held out for evaluation rather than training.
+validation_fraction = 0.2

--- a/config/default.toml
+++ b/config/default.toml
@@ -24,3 +24,5 @@ dataset_seed = 20260814
 init_seed = 7
 # Epochs between model checkpoints. Zero disables checkpointing.
 checkpoint_interval_epochs = 25
+# Fraction of the dataset held out for evaluation rather than training.
+validation_fraction = 0.2

--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -8,9 +8,9 @@ use crate::{
     common::{self, GradientReply, Task, TaskType},
     config::load_settings,
     database,
-    dataset::DatasetSpec,
+    dataset::{self, DatasetSpec},
     health, logging_metrics, messaging,
-    model::MlpSpec,
+    model::{self, MlpSpec, Sample},
     scheduler, signals,
 };
 use futures_util::stream::StreamExt;
@@ -102,6 +102,10 @@ pub struct AnNodeState {
     /// Sum of each shard's mean loss weighted by its sample count.
     loss_accumulator: f64,
     last_epoch_loss: Option<f32>,
+    /// Accuracy on the held-out set after the last completed epoch.
+    last_validation_accuracy: Option<f32>,
+    /// The held-out samples, generated once rather than per epoch.
+    validation: Vec<Sample>,
     epochs_completed: u64,
 }
 
@@ -119,8 +123,12 @@ impl AnNodeState {
         init_seed: u64,
     ) -> Self {
         let parameters = spec.initialize(init_seed);
+        let all_samples = dataset::generate(dataset);
+        let validation = dataset::validation(&dataset, &all_samples).to_vec();
         Self {
             accumulator: vec![0.0; parameters.len()],
+            last_validation_accuracy: None,
+            validation,
             spec,
             dataset,
             parameters,
@@ -184,9 +192,22 @@ impl AnNodeState {
         self.replies
     }
 
-    /// Mean loss of the last completed epoch, once one has completed.
+    /// Mean training loss of the last completed epoch, once one has completed.
     pub fn last_epoch_loss(&self) -> Option<f32> {
         self.last_epoch_loss
+    }
+
+    /// Accuracy on the held-out set after the last completed epoch.
+    ///
+    /// `None` when no epoch has completed, or when the dataset holds nothing
+    /// back — in which case there is no honest number to report.
+    pub fn last_validation_accuracy(&self) -> Option<f32> {
+        self.last_validation_accuracy
+    }
+
+    /// The held-out samples this node evaluates against.
+    pub fn validation_set(&self) -> &[Sample] {
+        &self.validation
     }
 
     pub fn epochs_completed(&self) -> u64 {
@@ -272,12 +293,25 @@ impl AnNodeState {
         self.last_epoch_loss =
             Some((self.loss_accumulator / self.accumulated_samples as f64) as f32);
         self.epochs_completed += 1;
+
+        // Evaluate on data no worker trained on. Accuracy over the training set
+        // would measure how well the model memorized it, not whether it
+        // generalized.
+        self.last_validation_accuracy = if self.validation.is_empty() {
+            None
+        } else {
+            model::accuracy(&self.spec, &self.parameters, &self.validation).ok()
+        };
+
         info!(
-            "Epoch {} complete over {} samples from {} shard(s): loss {:.5}",
+            "Epoch {} over {} samples from {} shard(s): training loss {:.5}, validation accuracy {}",
             self.epochs_completed,
             self.accumulated_samples,
             self.replies,
-            self.last_epoch_loss.unwrap_or(f32::NAN)
+            self.last_epoch_loss.unwrap_or(f32::NAN),
+            self.last_validation_accuracy
+                .map(|a| format!("{a:.4}"))
+                .unwrap_or_else(|| "n/a".to_string())
         );
 
         self.accumulator.iter_mut().for_each(|value| *value = 0.0);

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -35,8 +35,13 @@ pub struct Checkpoint {
 /// new run rather than silently loading incompatible weights.
 pub fn model_id(spec: &MlpSpec, dataset: &DatasetSpec) -> String {
     format!(
-        "in{}-h{}-out{}-n{}-seed{}",
-        spec.inputs, spec.hidden, spec.outputs, dataset.samples, dataset.seed
+        "in{}-h{}-out{}-n{}-val{}-seed{}",
+        spec.inputs,
+        spec.hidden,
+        spec.outputs,
+        dataset.samples,
+        dataset.validation_samples,
+        dataset.seed
     )
 }
 
@@ -201,6 +206,11 @@ mod tests {
             base,
             model_id(&spec(), &DatasetSpec::new(256, 20_260_814)),
             "a different dataset size is a different training run"
+        );
+        assert_ne!(
+            base,
+            model_id(&spec(), &DatasetSpec::with_validation(512, 20_260_814, 100)),
+            "a different hold-out means the model trained on different samples"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,9 @@ pub struct Settings {
     /// Seed for the initial parameters.
     #[serde(default = "default_init_seed")]
     pub init_seed: u64,
+    /// Fraction of the dataset held out for evaluation rather than training.
+    #[serde(default = "default_validation_fraction")]
+    pub validation_fraction: f32,
     /// Epochs between model checkpoints. Zero disables checkpointing.
     #[serde(default = "default_checkpoint_interval_epochs")]
     pub checkpoint_interval_epochs: u64,
@@ -67,6 +70,10 @@ fn default_init_seed() -> u64 {
 
 fn default_checkpoint_interval_epochs() -> u64 {
     25
+}
+
+fn default_validation_fraction() -> f32 {
+    0.2
 }
 
 fn default_epoch_interval_ms() -> u64 {
@@ -119,8 +126,17 @@ impl Settings {
     }
 
     /// Dataset every node reconstructs locally.
+    ///
+    /// The hold-out is resolved to an exact sample count here rather than
+    /// carried as a fraction, so every node divides the data at the same index
+    /// no matter how it rounds.
     pub fn dataset_spec(&self) -> crate::dataset::DatasetSpec {
-        crate::dataset::DatasetSpec::new(self.dataset_samples, self.dataset_seed)
+        let held_out = (self.dataset_samples as f32 * self.validation_fraction).round() as usize;
+        crate::dataset::DatasetSpec::with_validation(
+            self.dataset_samples,
+            self.dataset_seed,
+            held_out,
+        )
     }
 
     /// Network shape implied by the dataset and the configured hidden width.
@@ -146,11 +162,19 @@ impl Settings {
                 "learning_rate must be a positive, finite number".into(),
             ));
         }
-        if self.dataset_samples < self.model_shards {
+        if !(0.0..1.0).contains(&self.validation_fraction) {
+            // A fraction of 1.0 or more would leave nothing to train on.
+            return Err(ConfigError::Message(
+                "validation_fraction must be at least 0 and below 1".into(),
+            ));
+        }
+        if self.dataset_spec().training_samples() < self.model_shards {
             // Otherwise some shard is empty and its worker has no gradient to
             // return, so the round can never collect a full set.
             return Err(ConfigError::Message(
-                "dataset_samples must be at least model_shards".into(),
+                "training samples (after the validation hold-out) must be at least \
+                 model_shards"
+                    .into(),
             ));
         }
         // A zero interval would spin the scheduler as fast as the broker
@@ -240,6 +264,7 @@ mod tests {
             dataset_seed: 1,
             init_seed: 1,
             checkpoint_interval_epochs: 25,
+            validation_fraction: 0.2,
             epoch_interval_ms: 250,
         }
     }

--- a/src/dataset.rs
+++ b/src/dataset.rs
@@ -31,16 +31,47 @@ pub const OUTPUTS: usize = 2;
 /// model cannot score well by always guessing one class.
 const RADIUS: f32 = 0.797_884_6;
 
-/// Describes a dataset completely: same values, same samples, on any node.
+/// Describes a dataset completely: same values, same samples, same split, on
+/// any node.
+///
+/// `validation_samples` is stored as a count rather than a fraction so every
+/// node divides the data at exactly the same index. A fraction would have to be
+/// rounded, and two nodes disagreeing by one sample would put a validation point
+/// into someone's training shard.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DatasetSpec {
     pub samples: usize,
     pub seed: u64,
+    /// Samples held out for evaluation, taken from the end of the dataset.
+    #[serde(default)]
+    pub validation_samples: usize,
 }
 
 impl DatasetSpec {
+    /// A dataset with no held-out samples.
     pub fn new(samples: usize, seed: u64) -> Self {
-        Self { samples, seed }
+        Self {
+            samples,
+            seed,
+            validation_samples: 0,
+        }
+    }
+
+    /// A dataset holding out `validation_samples` for evaluation.
+    ///
+    /// The hold-out is clamped so at least one training sample remains: a split
+    /// that left nothing to train on would produce no gradients at all.
+    pub fn with_validation(samples: usize, seed: u64, validation_samples: usize) -> Self {
+        Self {
+            samples,
+            seed,
+            validation_samples: validation_samples.min(samples.saturating_sub(1)),
+        }
+    }
+
+    /// Samples available for training.
+    pub fn training_samples(&self) -> usize {
+        self.samples.saturating_sub(self.validation_samples)
     }
 
     /// The network shape this dataset calls for, given a hidden width.
@@ -93,6 +124,20 @@ pub fn shard_range(total: usize, index: usize, count: usize) -> std::ops::Range<
 /// Borrows shard `index` of `count` from `samples`.
 pub fn shard(samples: &[Sample], index: usize, count: usize) -> &[Sample] {
     &samples[shard_range(samples.len(), index, count)]
+}
+
+/// The portion of `samples` available for training.
+///
+/// Shards are cut from this slice only, so no validation sample can reach a
+/// worker's gradient. Measuring accuracy on data the model was fitted to says
+/// nothing about whether it generalized.
+pub fn training<'a>(spec: &DatasetSpec, samples: &'a [Sample]) -> &'a [Sample] {
+    &samples[..spec.training_samples().min(samples.len())]
+}
+
+/// The held-out portion of `samples`, taken from the end.
+pub fn validation<'a>(spec: &DatasetSpec, samples: &'a [Sample]) -> &'a [Sample] {
+    &samples[spec.training_samples().min(samples.len())..]
 }
 
 #[cfg(test)]
@@ -222,8 +267,74 @@ mod tests {
     }
 
     #[test]
+    fn training_and_validation_are_disjoint_and_cover_everything() {
+        let spec = DatasetSpec::with_validation(100, 3, 20);
+        let samples = generate(spec);
+
+        let train = training(&spec, &samples);
+        let holdout = validation(&spec, &samples);
+
+        assert_eq!(train.len(), 80);
+        assert_eq!(holdout.len(), 20);
+        assert_eq!(train.len() + holdout.len(), samples.len());
+        // Disjoint by construction, but assert it: a validation sample that
+        // leaked into training would make every reported accuracy meaningless.
+        for held in holdout {
+            assert!(!train.contains(held), "a held-out sample reached training");
+        }
+    }
+
+    #[test]
+    fn shards_never_reach_the_held_out_samples() {
+        let spec = DatasetSpec::with_validation(100, 3, 20);
+        let samples = generate(spec);
+        let train = training(&spec, &samples);
+        let holdout = validation(&spec, &samples);
+
+        for index in 0..4 {
+            for sample in shard(train, index, 4) {
+                assert!(!holdout.contains(sample));
+            }
+        }
+    }
+
+    #[test]
+    fn the_hold_out_never_consumes_the_whole_dataset() {
+        // A split leaving nothing to train on would produce no gradients at all.
+        let spec = DatasetSpec::with_validation(10, 1, 10);
+        assert_eq!(spec.training_samples(), 1);
+
+        let spec = DatasetSpec::with_validation(10, 1, 99);
+        assert_eq!(spec.training_samples(), 1);
+    }
+
+    #[test]
+    fn a_spec_without_a_hold_out_trains_on_everything() {
+        let spec = DatasetSpec::new(50, 1);
+        let samples = generate(spec);
+
+        assert_eq!(spec.training_samples(), 50);
+        assert_eq!(training(&spec, &samples).len(), 50);
+        assert!(validation(&spec, &samples).is_empty());
+    }
+
+    #[test]
     fn a_single_shard_is_the_whole_dataset() {
         let samples = generate(DatasetSpec::new(25, 4));
         assert_eq!(shard(&samples, 0, 1), &samples[..]);
+    }
+
+    #[test]
+    fn the_held_out_set_is_also_roughly_balanced() {
+        // A hold-out skewed to one class would make accuracy on it misleading.
+        let spec = DatasetSpec::with_validation(2_000, 5, 400);
+        let samples = generate(spec);
+        let held = validation(&spec, &samples);
+        let inside = held.iter().filter(|s| s.label == 1).count();
+        let fraction = inside as f32 / held.len() as f32;
+        assert!(
+            (0.40..=0.60).contains(&fraction),
+            "hold-out balance was {fraction}"
+        );
     }
 }

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -256,7 +256,10 @@ pub async fn perform_computation(task: Task) -> Result<Task, Box<dyn Error>> {
             let request: GradientRequest = serde_json::from_str(&task.data)?;
 
             let samples = dataset::generate(request.dataset);
-            let shard = dataset::shard(&samples, request.shard, request.shards);
+            // Shard the training portion only. A validation sample that reached
+            // a gradient would make the evaluation meaningless.
+            let training = dataset::training(&request.dataset, &samples);
+            let shard = dataset::shard(training, request.shard, request.shards);
             if shard.is_empty() {
                 // A shard with no samples has no gradient to report. Treat it as
                 // bad input rather than replying with zeros, which the An node
@@ -264,10 +267,10 @@ pub async fn perform_computation(task: Task) -> Result<Task, Box<dyn Error>> {
                 return Err(IoError::new(
                     ErrorKind::InvalidData,
                     format!(
-                        "shard {} of {} is empty for a {}-sample dataset",
+                        "shard {} of {} is empty for a {}-sample training set",
                         request.shard,
                         request.shards,
-                        samples.len()
+                        training.len()
                     ),
                 )
                 .into());

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -175,7 +175,7 @@ mod tests {
     }
 
     fn data() -> DatasetSpec {
-        DatasetSpec::new(256, 20_260_814)
+        DatasetSpec::with_validation(320, 20_260_814, 64)
     }
 
     #[test]
@@ -282,20 +282,49 @@ mod tests {
     /// evidence that the gradients were computed, shipped, averaged, and applied
     /// correctly at every step.
     #[tokio::test]
-    async fn training_across_four_shards_learns_the_task() {
+    async fn training_across_four_shards_generalizes_to_held_out_data() {
         let state = train(4, 400).await;
 
-        let samples = dataset::generate(data());
-        let accuracy =
-            model::accuracy(&state.spec(), state.parameters(), &samples).expect("accuracy");
+        // Measured on samples no worker ever received. Accuracy over the
+        // training set would only show how well the model memorized it.
+        let accuracy = state
+            .last_validation_accuracy()
+            .expect("an epoch completed with a hold-out");
         let loss = state.last_epoch_loss().expect("an epoch completed");
 
         assert_eq!(state.epochs_completed(), 400);
         assert!(
-            accuracy > 0.85,
-            "expected the model to learn the circle, got accuracy {accuracy} (loss {loss})"
+            !state.validation_set().is_empty(),
+            "the hold-out must be non-empty for this assertion to mean anything"
         );
-        assert!(loss < 0.25, "loss stalled at {loss}");
+        assert!(
+            accuracy > 0.85,
+            "expected the model to generalize, got validation accuracy {accuracy} \
+             (training loss {loss})"
+        );
+        assert!(loss < 0.25, "training loss stalled at {loss}");
+    }
+
+    /// Held-out accuracy should track training accuracy closely on a task this
+    /// small. A large gap would mean the model memorized the training shards
+    /// rather than learning the boundary.
+    #[tokio::test]
+    async fn held_out_accuracy_tracks_training_accuracy() {
+        let state = train(4, 400).await;
+        let samples = dataset::generate(data());
+
+        let on_training = model::accuracy(
+            &state.spec(),
+            state.parameters(),
+            dataset::training(&data(), &samples),
+        )
+        .expect("training accuracy");
+        let on_holdout = state.last_validation_accuracy().expect("validation");
+
+        assert!(
+            (on_training - on_holdout).abs() < 0.15,
+            "training {on_training} vs held-out {on_holdout} suggests memorization"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
> 3 of 3. Rebased onto `main` now that #149 and #150 have merged, so this is a clean single commit.

Accuracy was measured over the same samples the model was fitted to. That reports **memorization, not generalization**. On a task this small the two are probably close — but nothing demonstrated that, so the headline "99% accuracy" wasn't evidence of what it appeared to claim.

## The split

A fifth of the dataset is now reserved. **Shards are cut from the training portion only**, so no worker ever computes a gradient on a held-out sample. The An node evaluates against that set after every epoch and logs it alongside the training loss:

```
Epoch 400 over 205 samples from 4 shard(s): training loss 0.09942, validation accuracy 0.9804
```

## An exact count, not a fraction, on the wire

`DatasetSpec` carries `validation_samples` as a **count**, so every node divides the data at the same index by construction. A fraction would have to be rounded, and two nodes disagreeing by one sample would quietly move a validation point into someone's training shard — a silent correctness bug that would inflate the reported accuracy. Configuration still expresses it as `validation_fraction` and resolves it to a count in exactly one place.

## Guard rails

- The split is clamped so at least one training sample always remains.
- `validation_fraction` is rejected at or above 1.0 — a split leaving nothing to train on produces no gradients at all.
- The shard-count check now validates against the **training** portion rather than the whole dataset, since that's what shards are cut from.
- The hold-out joins the checkpoint fingerprint: changing it changes which samples the model trained on, so it's a different run and must not resume into the old one.

## Tests

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 152 → 158.

- `shards_never_reach_the_held_out_samples` — the guarantee the entire evaluation rests on.
- `training_across_four_shards_generalizes_to_held_out_data` — the convergence test now asserts accuracy on data no worker received.
- `held_out_accuracy_tracks_training_accuracy` — a large gap between the two would mean memorization; this pins them within 15 points.
- `the_held_out_set_is_also_roughly_balanced` — a skewed hold-out would make accuracy on it misleading.

---

## Unrelated flake I hit while testing

`raft_store::tests::vote_survives_reopening_the_database` failed **once** during a full-suite run, at the *reopen*:

```
panicked at src/raft_store.rs:655: reopen store
```

It then passed on five consecutive isolated re-runs and on the next full-suite run. The shape fits a sled file-lock release race: the test drops the store and immediately reopens the same directory, and under full-suite parallelism the lock may not yet be released.

That test came from #138 and is unrelated to this change, so I left it alone rather than muddy this PR. It will redden CI intermittently and deserves its own fix — retrying the open briefly, or closing the database explicitly before reopening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_