### PR TITLE
Run the integration suite in CI, and make it fail when it cannot

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,3 +34,70 @@ jobs:
         run: cargo fmt --check
       - name: Test
         run: cargo test
+
+  # The `integration-tests` feature covers the RabbitMQ, PostgreSQL, and REST
+  # API paths. Until now it ran nowhere, so those paths had no automated
+  # coverage at all — the in-process tests stop at the edge of the broker.
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      rabbitmq:
+        image: rabbitmq:3-alpine
+        ports:
+          - 5672:5672
+        options: >-
+          --health-cmd "rabbitmq-diagnostics -q ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: an_ki
+          POSTGRES_PASSWORD: an_ki
+          POSTGRES_DB: an_ki_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      # Both are read by the configuration loader's unprefixed overrides, so the
+      # suite talks to the service containers rather than config/default.toml.
+      AMQP_ADDR: amqp://127.0.0.1:5672/%2f
+      DATABASE_URL: postgresql://an_ki:an_ki@127.0.0.1:5432/an_ki_test
+      JWT_SECRET_KEY: ci-integration-secret
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
+      # Service health checks cover process start, but a broker can accept a TCP
+      # connection slightly before it is ready to serve. Failing here names the
+      # problem as "the service never came up" rather than as a test failure.
+      - name: Wait for the services
+        run: |
+          for i in $(seq 1 30); do
+            if (echo > /dev/tcp/127.0.0.1/5672) 2>/dev/null \
+               && (echo > /dev/tcp/127.0.0.1/5432) 2>/dev/null; then
+              echo "services are accepting connections"; exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::RabbitMQ or PostgreSQL did not become reachable"; exit 1
+      # Single-threaded deliberately. `security::tests` set and clear
+      # `JWT_SECRET_KEY` and `RUN_ENV`, which are process-global, and the API and
+      # checkpoint tests read those same variables to mint and verify tokens.
+      # Run in parallel they can observe each other's mutations and fail for
+      # reasons unrelated to the code under test. Serializing sidesteps that; the
+      # real fix is for those tests to stop mutating ambient environment, which
+      # is a larger change than belongs here.
+      - name: Integration tests
+        run: cargo test --features integration-tests -- --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The `integration-tests` suite now runs in CI against RabbitMQ and PostgreSQL
+  service containers. It previously ran nowhere, so the broker, database, and
+  REST API paths had no automated coverage. Several of those tests also returned
+  early when their service was unreachable, which made a missing service
+  indistinguishable from a passing test; they now fail.
+- Integration tests use per-run queue names instead of sharing fixed ones, so
+  parallel tests can no longer consume each other's messages.
+
 - Opening the Raft store now retries briefly on I/O failure. sled holds an
   exclusive directory lock that is released when the previous handle drops, so a
   container restarting promptly could race the departing process and fail to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,30 @@ cargo test
 
 Note `--all-targets`: without it clippy skips test code.
 
-Tests requiring a live broker or database are behind a feature flag and do not
-run by default or in CI:
+Tests requiring a live broker or database are behind a feature flag, so they do
+not run by default:
 
 ```bash
 cargo test --features integration-tests
 ```
+
+They **do** run in CI, against RabbitMQ and PostgreSQL service containers. To
+run them locally, start both and point the suite at them:
+
+```bash
+docker run -d -p 5672:5672 rabbitmq:3-alpine
+docker run -d -p 5432:5432 -e POSTGRES_USER=an_ki -e POSTGRES_PASSWORD=an_ki \
+  -e POSTGRES_DB=an_ki_test postgres:16-alpine
+
+AMQP_ADDR=amqp://127.0.0.1:5672/%2f \
+DATABASE_URL=postgresql://an_ki:an_ki@127.0.0.1:5432/an_ki_test \
+JWT_SECRET_KEY=local-test-secret \
+  cargo test --features integration-tests -- --test-threads=1
+```
+
+These tests must never skip themselves when a service is unreachable. A test
+that quietly passes without a broker is worse than no test: it reports coverage
+it does not have.
 
 Chart changes are validated by the Deploy Checks workflow, which runs
 `helm lint` and renders the templates against every values file.

--- a/README.md
+++ b/README.md
@@ -477,7 +477,8 @@ excluded from the default run:
 cargo test --features integration-tests
 ```
 
-These are not currently run in CI; they need a broker and a database available.
+These run in CI against RabbitMQ and PostgreSQL service containers. See
+[CONTRIBUTING.md](CONTRIBUTING.md#checks) for running them locally.
 
 ### Building
 

--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -847,23 +847,21 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     use lapin::options::BasicAckOptions;
     #[cfg(feature = "integration-tests")]
-    const AMQP_ADDR: &str = "amqp://127.0.0.1:5672/%2f";
-
-    #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn test_setup_consumer_workflow() {
-        let (_channel, mut consumer) = messaging::connect_with_retries(
-            AMQP_ADDR,
-            "test_queue",
+        let queue = messaging::integration_queue("an-consumer");
+        let (channel, mut consumer) = messaging::connect_with_retries(
+            &messaging::integration_amqp_addr(),
+            &queue,
             "test_consumer",
             1,
             10,
             10_000,
         )
         .await
-        .expect("setup");
+        .expect("connect to the broker");
 
-        messaging::publish_message(&channel, "test_queue", b"hello")
+        messaging::publish_message(&channel, &queue, b"hello")
             .await
             .expect("publish");
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -68,28 +68,34 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic_query() {
-        let pool = match get_pool().await {
-            Ok(pool) => pool,
-            Err(e) => panic!("Failed to create pool: {}", e),
-        };
-        let conn = match pool.get().await {
-            Ok(conn) => conn,
-            Err(e) => {
-                eprintln!(
-                    "Skipping test_basic_query: failed to get connection from pool: {}",
-                    e
-                );
-                return;
-            }
-        };
-        let row = match conn.query_one("SELECT 1", &[]).await {
-            Ok(row) => row,
-            Err(e) => {
-                eprintln!("Skipping test_basic_query: query failed: {}", e);
-                return;
-            }
-        };
+        // Previously this skipped itself when the database was unreachable,
+        // which made an unreachable database indistinguishable from a passing
+        // test. The suite is gated behind `integration-tests` precisely because
+        // it requires a database, so not having one is a failure.
+        let pool = get_pool().await.expect("connect to the database");
+        let conn = pool.get().await.expect("take a connection from the pool");
+        let row = conn.query_one("SELECT 1", &[]).await.expect("run a query");
+
         let value: i32 = row.get(0);
         assert_eq!(value, 1);
+    }
+
+    #[tokio::test]
+    async fn migrations_create_every_table_the_code_reads() {
+        // `get_pool` runs the migrations, so reaching these tables proves they
+        // exist with the columns the queries name.
+        let pool = get_pool().await.expect("connect to the database");
+        let conn = pool.get().await.expect("connection");
+
+        conn.query_opt("SELECT task_id, task_type, data FROM tasks LIMIT 1", &[])
+            .await
+            .expect("tasks table is queryable");
+        conn.query_opt(
+            "SELECT checkpoint_id, model_id, epoch, parameters, loss \
+             FROM model_checkpoints LIMIT 1",
+            &[],
+        )
+        .await
+        .expect("model_checkpoints table is queryable");
     }
 }

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -507,14 +507,12 @@ mod tests {
         use futures_util::StreamExt;
         use tokio::time::{timeout, Duration};
 
-        const AMQP_ADDR: &str = "amqp://127.0.0.1:5672/%2f";
+        let channel = messaging::establish_connection(&messaging::integration_amqp_addr())
+            .await
+            .expect("connect to the broker");
+        let queue = messaging::integration_queue("an-task");
 
-        let channel = match messaging::establish_connection(AMQP_ADDR).await {
-            Ok(ch) => ch,
-            Err(_) => return, // RabbitMQ not available
-        };
-
-        messaging::declare_queue(&channel, "an_task_queue")
+        messaging::declare_queue(&channel, &queue)
             .await
             .expect("declare result queue");
 

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -91,6 +91,25 @@ pub async fn publish_message(
     }
 }
 
+/// Broker address integration tests connect to.
+///
+/// Honours `AMQP_ADDR` so CI can point the suite at a service container, and
+/// falls back to a local broker for developers running one by hand.
+#[cfg(feature = "integration-tests")]
+pub fn integration_amqp_addr() -> String {
+    std::env::var("AMQP_ADDR").unwrap_or_else(|_| "amqp://127.0.0.1:5672/%2f".to_string())
+}
+
+/// A queue name unique to one test run.
+///
+/// Integration tests run in parallel against one broker. Sharing a queue name
+/// lets one test consume another's message, which fails intermittently and for
+/// reasons that have nothing to do with the code under test.
+#[cfg(feature = "integration-tests")]
+pub fn integration_queue(prefix: &str) -> String {
+    format!("{prefix}-{}", uuid::Uuid::new_v4())
+}
+
 pub async fn consume_messages(
     channel: &Channel,
     queue_name: &str,
@@ -181,25 +200,23 @@ mod tests {
     use lapin::options::BasicAckOptions;
 
     #[cfg(feature = "integration-tests")]
-    const AMQP_ADDR: &str = "amqp://127.0.0.1:5672/%2f";
-
-    #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn test_messaging_workflow() {
-        let channel = match establish_connection(AMQP_ADDR).await {
-            Ok(ch) => ch,
-            Err(_) => return,
-        };
-
-        declare_queue(&channel, "test_queue")
+        // No skip-on-unreachable: this test exists to prove the broker path
+        // works, and a version that passes when there is no broker proves
+        // nothing while looking like coverage.
+        let channel = establish_connection(&integration_amqp_addr())
             .await
-            .expect("declare");
+            .expect("connect to the broker");
+        let queue = integration_queue("test-messaging");
 
-        publish_message(&channel, "test_queue", b"hello")
+        declare_queue(&channel, &queue).await.expect("declare");
+
+        publish_message(&channel, &queue, b"hello")
             .await
             .expect("publish");
 
-        let mut consumer = consume_messages(&channel, "test_queue", "test_consumer")
+        let mut consumer = consume_messages(&channel, &queue, "test_consumer")
             .await
             .expect("consume");
 
@@ -259,16 +276,14 @@ mod tests {
     #[cfg(feature = "integration-tests")]
     #[tokio::test]
     async fn test_connect_with_retries_success() {
-        let res =
-            connect_with_retries(AMQP_ADDR, "test_queue_retry", "test_tag", 1, 10, 10_000).await;
-        match res {
-            Ok((channel, consumer)) => {
-                // drop consumer to close
-                drop(consumer);
-                drop(channel);
-            }
-            Err(_) => return, // skip if RabbitMQ not available
-        }
+        let queue = integration_queue("test-retry");
+        let (channel, consumer) =
+            connect_with_retries(&integration_amqp_addr(), &queue, "test_tag", 1, 10, 10_000)
+                .await
+                .expect("connect to the broker");
+
+        drop(consumer);
+        drop(channel);
     }
 
     #[tokio::test]


### PR DESCRIPTION
> **Stacked on #152.** Merge that first. (2 of 2 toward an honest suite.)

The `integration-tests` feature covers the RabbitMQ, PostgreSQL, and REST API paths. **It ran nowhere.** Every claim about those paths rested on tests that had never once executed, and the in-process tests stop at the edge of the broker.

CI now runs them against RabbitMQ and PostgreSQL service containers — about 20 tests across `messaging`, `an_node`, `ki_node`, `api`, `task_recovery`, `checkpoint`, and `database`.

## Turning them on wasn't enough

Several returned early when their service was unreachable:

```rust
let channel = match establish_connection(AMQP_ADDR).await {
    Ok(ch) => ch,
    Err(_) => return,   // RabbitMQ not available
};
```

**A test shaped like that passes whether or not the broker exists.** It makes a missing service indistinguishable from working code and reports coverage it doesn't have — worse than no test, because it looks like one. The suite is gated behind a feature *precisely because* it needs those services, so their absence is a failure, not a reason to skip.

Every such early return is now an expectation, in `messaging`, `ki_node`, `an_node`, and `database`. `test_basic_query` was the worst offender: it caught both the pool failure and the query failure, printed "Skipping", and returned green.

## Two isolation problems that would have flaked immediately

**Shared queue names.** `messaging::test_messaging_workflow` and `an_node::test_setup_consumer_workflow` both published `b"hello"` to `test_queue`. Run in parallel against one broker, either can consume the other's message. Queue names are now unique per run, and the broker address comes from `AMQP_ADDR`.

**Process-global env vars.** `security::tests` set and clear `JWT_SECRET_KEY` and `RUN_ENV`; the API and checkpoint tests read those same variables to mint and verify tokens. In parallel they can observe each other's mutations — a token minted under one secret, verified under another, is a 401 and a failing test that has nothing to do with the code.

The job therefore runs `--test-threads=1`. **That sidesteps the cause rather than fixing it** — the real fix is for `security::tests` to stop mutating ambient environment — but serializing ~160 fast tests costs about six seconds, and it makes the difference between a suite that can be trusted and one that flakes on merge.

## Also

A `migrations_create_every_table_the_code_reads` test asserting every table the code queries exists with the columns the queries name. The schema had already drifted once — `model_checkpoints` sat unused for months with a shape that couldn't hold a checkpoint.

The job waits for both services to accept TCP before running, so "the service never came up" is reported as that rather than as a mysterious test failure.

## What I could and could not verify

`cargo fmt --check`, `cargo clippy --all-targets --features integration-tests -- -D warnings`, and the default suite (160 tests) all pass, including single-threaded. I confirmed the workflow parses and that `--features integration-tests` compiles cleanly.

**I could not execute the integration tests** — no Docker in my environment. Their first real run will be this PR's CI. If something needs adjusting it'll most likely be service startup timing or a Postgres-vs-CockroachDB SQL difference; I checked the migrations are plain Postgres DDL (`UUID`, `BYTEA`, `TIMESTAMPTZ`, `REAL`), but reading SQL is not running it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_