### PR TITLE
Fix helm lint: give the headless service its own template file

### DIFF
--- a/helm/an-ki/templates/principal-headless-service.yaml
+++ b/helm/an-ki/templates/principal-headless-service.yaml
@@ -1,0 +1,21 @@
+# Headless service backing the StatefulSet. It gives every principal a stable
+# per-pod DNS name (principal-0.principal-headless, ...), which is how peers
+# address each other over the Raft transport.
+apiVersion: v1
+kind: Service
+metadata:
+  name: principal-headless
+spec:
+  clusterIP: None
+  selector:
+    app: principal
+  # Published before the pod is ready so principals can reach each other while
+  # the cluster is still forming its first quorum.
+  publishNotReadyAddresses: true
+  ports:
+    - name: api
+      port: 3030
+      targetPort: 3030
+    - name: raft
+      port: {{ .Values.principal.raftPort }}
+      targetPort: {{ .Values.principal.raftPort }}

--- a/helm/an-ki/templates/principal-service.yaml
+++ b/helm/an-ki/templates/principal-service.yaml
@@ -8,27 +8,3 @@ spec:
   ports:
     - port: 3030
       targetPort: 3030
----
-{{- /*
-Headless service backing the StatefulSet. It gives every principal a stable
-per-pod DNS name (principal-0.principal-headless, ...), which is how peers will
-address each other once the Raft transport lands.
-*/ -}}
-apiVersion: v1
-kind: Service
-metadata:
-  name: principal-headless
-spec:
-  clusterIP: None
-  selector:
-    app: principal
-  # Published before the pod is ready so principals can reach each other while
-  # the cluster is still forming its first quorum.
-  publishNotReadyAddresses: true
-  ports:
-    - name: api
-      port: 3030
-      targetPort: 3030
-    - name: raft
-      port: {{ .Values.principal.raftPort }}
-      targetPort: {{ .Values.principal.raftPort }}


### PR DESCRIPTION
## The bug is on `main`, not in a feature branch

`helm lint` has been failing since #138 merged:

```
[ERROR] templates/principal-service.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1
```

Deploy Checks has been red on every commit since. I introduced this and did not
notice, so this PR is a fix to `main` rather than part of any stack.

## Cause

Go template whitespace trimming. #138 appended the headless service to
`principal-service.yaml` after a `---` separator and introduced it with a
`{{- /* ... */ -}}` comment:

```yaml
---
{{- /*
Headless service backing the StatefulSet...
*/ -}}
apiVersion: v1
```

The leading `{{-` trims **all** preceding whitespace — including the newline
that ends the `---` line. The rendered output is `---apiVersion: v1` on a
single line, which is not a document separator, so the second document never
starts and the parse fails on the first `:` it hits.

## Fix

The one-character fix is `{{ /* ... */ }}`, but a template that only parses
because of where its dashes happen to sit is a trap for whoever edits it next.
Every other template in this chart holds exactly one resource, so this one now
does too. The headless service moves to `principal-headless-service.yaml` and
the `---` disappears along with it. The explanatory comment becomes a plain
YAML `#` comment, which no amount of template trimming can eat.

No rendered output changes: the same two Services with the same fields, just
delivered as two files instead of one.

## What I verified, and what I could not

I cannot run `helm` here — `get.helm.sh` is blocked by this environment's
network policy — which is exactly how the bug reached `main`: my local
approximation of Go template trimming got this case wrong. I rewrote that
approximation to model `{{-`/`-}}` trimming properly and it now reproduces the
failure on the old file and parses all seven templates cleanly on the new one.
That is evidence, not proof. **CI is authoritative**; the `helm` job on this PR
is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_