### PR TITLE
Make the integration job actually run the integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,8 +58,14 @@ jobs:
           POSTGRES_DB: an_ki_test
         ports:
           - 5432:5432
+        # `pg_isready` with no arguments connects as the invoking OS user, and
+        # the health check runs as root inside the container. Setting
+        # POSTGRES_USER means there is no `root` role *and* no `postgres` role,
+        # so the bare form logs `FATAL: role "root" does not exist` forever and
+        # the service never reports healthy — the job then dies before a single
+        # test runs. Name the role and database explicitly.
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U an_ki -d an_ki_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 12


### PR DESCRIPTION
Follow-up to #153, which merged with a broken service health check. Two
commits, both found by running the thing.

## 1. The integration job had never run a test

The postgres service container logged this once every ten seconds — the
health-check interval — until the retries ran out and the job was cancelled:

```
2026-08-14 23:26:53.434 UTC [67] FATAL:  role "root" does not exist
2026-08-14 23:27:03.489 UTC [75] FATAL:  role "root" does not exist
```

`pg_isready` with no arguments connects as the invoking OS user, and the health
check runs as root via `docker exec`. Because the job sets `POSTGRES_USER:
an_ki`, the image creates `an_ki` *instead of* the default `postgres` role — so
neither `root` nor `postgres` exists and the probe can never succeed. The
service never reported healthy and the job died before `cargo test` was reached.

```yaml
--health-cmd "pg_isready -U an_ki -d an_ki_test"
```

#153's whole argument was that a test which passes when its service is missing
is worse than no test. The job I wrote to fix that had the same defect one level
up: its red/green signal was entirely about container health and said nothing
about the code.

## 2. With that fixed, the suite ran — 179 passed, 1 failed

```
ki_node::tests::test_send_result_publishes_message
consume result queue: NOT_FOUND - no queue 'an_task_queue' in vhost '/'
```

Also mine, from #153. That test declares a unique queue so parallel runs cannot
consume each other's messages — and then consumed the hard-coded `an_task_queue`
anyway, because `send_result` published to a literal the test had no way to
change. So the unique queue was declared and never used, and the consume named a
queue nothing had declared.

`send_result` now takes the queue as an argument, which is what lets a test point
one publish somewhere private. Both ends of that queue were spelling the name out
for themselves, so it becomes `scheduler::AN_RESULT_QUEUE` next to the existing
`KI_TASK_QUEUE` — a typo on either side of a queue name yields a node that
connects, consumes nothing, and reports no error, which is a bad way to find out.

## Worth reading the run for

That first execution is the useful artifact here. 179 tests across `messaging`,
`an_node`, `ki_node`, `api`, `task_recovery`, `checkpoint`, and `database` ran
against real RabbitMQ and PostgreSQL, and exactly one of them was wrong. The
migrations applied cleanly to Postgres 16 and every table the code queries was
reachable.

I still cannot run these locally (no Docker here); `cargo fmt --check`,
`cargo clippy --all-targets --features integration-tests -- -D warnings`, and
the default suite pass. CI is the check that matters for the rest.