### PR TITLE
Publish the result to the queue the test is listening on

### DIFF
--- a/src/an_node.rs
+++ b/src/an_node.rs
@@ -469,7 +469,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
         .parse()
         .unwrap_or(5_000);
 
-    let queue_name = "an_task_queue";
+    let queue_name = crate::scheduler::AN_RESULT_QUEUE;
     let consumer_tag = "an_consumer";
     let mut last_checkpointed_epoch = 0_u64;
 

--- a/src/ki_node.rs
+++ b/src/ki_node.rs
@@ -8,6 +8,7 @@ use crate::health;
 use crate::logging_metrics;
 use crate::messaging;
 use crate::model;
+use crate::scheduler;
 use crate::signals;
 use futures_util::stream::StreamExt;
 use lapin::{
@@ -237,7 +238,7 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
 async fn process_and_send_task(task: Task, channel: &Channel) -> Result<(), Box<dyn Error>> {
     let started_at = Instant::now();
     let result = perform_computation(task).await?;
-    send_result(result, channel).await?;
+    send_result(result, channel, scheduler::AN_RESULT_QUEUE).await?;
     // Only successful tasks are counted: a task that failed was not processed,
     // and counting it would inflate the throughput panel during an outage.
     logging_metrics::record_task_processed(started_at);
@@ -310,8 +311,16 @@ pub async fn perform_computation(task: Task) -> Result<Task, Box<dyn Error>> {
     }
 }
 
-async fn send_result(result: Task, channel: &Channel) -> Result<(), Box<dyn Error>> {
-    let result_queue = "an_task_queue";
+/// Publishes a completed task onto `result_queue`.
+///
+/// The queue is a parameter rather than a literal so a test can point one
+/// publish at a queue of its own; production always passes
+/// [`scheduler::AN_RESULT_QUEUE`].
+async fn send_result(
+    result: Task,
+    channel: &Channel,
+    result_queue: &str,
+) -> Result<(), Box<dyn Error>> {
     let payload = serde_json::to_vec(&result).map_err(|e| {
         error!("Failed to serialize result: {:?}", e);
         e
@@ -521,11 +530,11 @@ mod tests {
             task_type: TaskType::GradientUpdate,
             data: "ok".into(),
         };
-        send_result(result.clone(), &channel)
+        send_result(result.clone(), &channel, &queue)
             .await
             .expect("send result");
 
-        let mut consumer = messaging::consume_messages(&channel, "an_task_queue", "test_cons")
+        let mut consumer = messaging::consume_messages(&channel, &queue, "test_cons")
             .await
             .expect("consume result queue");
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -30,6 +30,12 @@ use crate::model::MlpSpec;
 /// Queue Ki nodes take their work from.
 pub const KI_TASK_QUEUE: &str = "ki_task_queue";
 
+/// Queue Ki nodes publish their gradients back onto, and the An node consumes.
+/// Both ends previously spelled the name out for themselves, which is a
+/// silent-failure waiting to happen: a typo on either side is a node that
+/// connects, consumes nothing, and reports no error.
+pub const AN_RESULT_QUEUE: &str = "an_task_queue";
+
 /// Builds the tasks that make up one epoch: one gradient request per shard,
 /// each naming a different slice of the dataset.
 ///


### PR DESCRIPTION
**`main` is red on `integration` right now; this is the fix.**

#155 merged with only its first commit — the health check. This is the second
commit from that branch, rebased onto `main`.

## What the working job found

With the health check fixed, the integration suite ran for the first time:
**179 passed, 1 failed.**

```
ki_node::tests::test_send_result_publishes_message
consume result queue: NOT_FOUND - no queue 'an_task_queue' in vhost '/'
```

Mine, from #153. That test declares a unique queue so parallel runs cannot
consume each other's messages — and then consumed the hard-coded
`an_task_queue` anyway, because `send_result` published to a literal the test
had no way to redirect. The unique queue was declared and never used, and the
consume named a queue nothing had declared.

## Fix

`send_result` takes the queue as an argument, which is what lets a test point one
publish somewhere private. Both ends of that queue were spelling the name out for
themselves — `ki_node` when publishing, `an_node` when consuming — so it becomes
`scheduler::AN_RESULT_QUEUE` next to the existing `KI_TASK_QUEUE`. A typo on
either side of a queue name yields a node that connects, consumes nothing, and
reports no error, which is a bad way to find out.

## Verified

`cargo fmt --check`, `cargo clippy --all-targets --features integration-tests -- -D warnings`,
and `cargo test` (162) pass locally. The integration job on this PR is the real
check, and it should also be the first run to exercise #157's
`a_restart_does_not_drop_saved_checkpoints` against a real database.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C12LeVGFd2e1E2e4mNfsGk)_